### PR TITLE
Fix task filtering in Today and Upcoming views

### DIFF
--- a/src/components/TaskManagement.tsx
+++ b/src/components/TaskManagement.tsx
@@ -462,8 +462,8 @@ export function TaskManagement() {
     return "yesterday";
   };
   const renderUpcomingView = () => {
-    // Get all tasks with due dates (excluding today), then apply completion filtering
-    let upcomingTasks = tasks.filter(task => task.dueDate && !isToday(task.dueDate));
+    // Get all tasks with due dates (including today and future), then apply completion filtering
+    let upcomingTasks = tasks.filter(task => task.dueDate);
 
     // Apply completion filter specifically for upcoming view
     if (!showCompleted) {


### PR DESCRIPTION
## Purpose

The user wanted to fix task filtering behavior in the Today and Upcoming views to ensure proper display of tasks based on due dates and completion status. The main goals were:

- Today view should show tasks due on or before today
- When "show completed" is enabled in Today view, only show tasks completed today (not previous days)
- Upcoming view should properly handle completed task filtering to only show tasks completed today or later
- Fix visibility issues where task groups appeared with counters but no visible tasks

## Code changes

- **Updated Today view filtering**: Changed from `isToday(task.dueDate)` to `task.dueDate <= endOfDay(new Date())` to include overdue tasks
- **Enhanced completion filtering logic**: Added specific handling for Today and Upcoming views when `showCompleted` is true
- **Fixed Upcoming view task filtering**: Modified to include all tasks with due dates and apply proper completion filtering
- **Added mock task**: Included a completed task with yesterday's due date for testing
- **Imported `endOfDay`**: Added date-fns utility for proper date boundary handling
- **Removed redundant filtering**: Fixed task rendering in groups to avoid double-filtering

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 9`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d4be3f38f3074d1faf4947ba0aa5919a/zen-nest)

👀 [Preview Link](https://d4be3f38f3074d1faf4947ba0aa5919a-zen-nest.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d4be3f38f3074d1faf4947ba0aa5919a</projectId>-->
<!--<branchName>zen-nest</branchName>-->