### PR TITLE
Add inline editing for step names in project view

### DIFF
--- a/src/components/ProjectManagement.tsx
+++ b/src/components/ProjectManagement.tsx
@@ -213,6 +213,8 @@ export function ProjectManagement({
   const [isEditing, setIsEditing] = useState(false);
   const [sortBy, setSortBy] = useState<"status" | "date" | "area" | "none">("none");
   const [newStepTitle, setNewStepTitle] = useState("");
+  const [editingStepId, setEditingStepId] = useState<string | null>(null);
+  const [editingStepTitle, setEditingStepTitle] = useState("");
   const [newProject, setNewProject] = useState({
     title: "",
     description: "",
@@ -308,6 +310,38 @@ export function ProjectManagement({
     setProjects(prevProjects => prevProjects.map(project =>
       project.id === editingProject.id ? updatedProject : project
     ));
+  };
+
+  const startEditingStep = (stepId: string, currentTitle: string) => {
+    setEditingStepId(stepId);
+    setEditingStepTitle(currentTitle);
+  };
+
+  const saveStepTitle = () => {
+    if (!editingProject || !editingStepId || !editingStepTitle.trim()) {
+      cancelStepEdit();
+      return;
+    }
+
+    const updatedProject = {
+      ...editingProject,
+      steps: editingProject.steps.map(step =>
+        step.id === editingStepId ? { ...step, title: editingStepTitle.trim() } : step
+      )
+    };
+
+    setEditingProject(updatedProject);
+    setProjects(prevProjects => prevProjects.map(project =>
+      project.id === editingProject.id ? updatedProject : project
+    ));
+
+    setEditingStepId(null);
+    setEditingStepTitle("");
+  };
+
+  const cancelStepEdit = () => {
+    setEditingStepId(null);
+    setEditingStepTitle("");
   };
 
   const addProject = () => {
@@ -603,12 +637,34 @@ export function ProjectManagement({
                               onChange={() => toggleStep(step.id)}
                               className="w-4 h-4 rounded focus:ring-2"
                             />
-                            <h4 className={cn(
-                              "font-medium text-foreground",
-                              step.completed && "line-through opacity-60"
-                            )}>
-                              {step.title}
-                            </h4>
+                            {editingStepId === step.id ? (
+                              <Input
+                                value={editingStepTitle}
+                                onChange={(e) => setEditingStepTitle(e.target.value)}
+                                onBlur={saveStepTitle}
+                                onKeyDown={(e) => {
+                                  if (e.key === 'Enter') {
+                                    saveStepTitle();
+                                  } else if (e.key === 'Escape') {
+                                    cancelStepEdit();
+                                  }
+                                }}
+                                className="h-6 border-none p-0 bg-transparent focus-visible:ring-1 focus-visible:ring-primary font-medium"
+                                autoFocus
+                                onFocus={(e) => e.target.select()}
+                              />
+                            ) : (
+                              <h4
+                                className={cn(
+                                  "font-medium text-foreground cursor-pointer hover:bg-muted/30 px-1 py-0.5 rounded transition-colors",
+                                  step.completed && "line-through opacity-60"
+                                )}
+                                onClick={() => startEditingStep(step.id, step.title)}
+                                title="Click to edit step name"
+                              >
+                                {step.title}
+                              </h4>
+                            )}
                             <span className="text-xs text-muted-foreground">
                               ({stepTasks.length} tasks)
                             </span>


### PR DESCRIPTION
## Purpose

Enable users to edit step names directly in the detailed project view without opening dialog popups. This improves the user experience by providing a more streamlined way to modify step titles inline.

## Code changes

- Added state management for inline step editing (`editingStepId`, `editingStepTitle`)
- Implemented `startEditingStep()` function to initiate editing mode
- Added `saveStepTitle()` function to persist changes and update project state
- Added `cancelStepEdit()` function to exit editing mode without saving
- Modified step title rendering to conditionally show either:
  - Input field for editing (with Enter/Escape key handling and auto-focus)
  - Clickable title text that triggers edit mode on click
- Enhanced UI with hover effects and visual feedback for editable step names

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 13`

🔗 [Edit in Builder.io](https://builder.io/app/projects/cce486bec28a4914a0e4a0d958006b51/cosmos-realm)

👀 [Preview Link](https://cce486bec28a4914a0e4a0d958006b51-cosmos-realm.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>cce486bec28a4914a0e4a0d958006b51</projectId>-->
<!--<branchName>cosmos-realm</branchName>-->