### PR TITLE
Remove task descriptions from card views and redesign sidebar

### DIFF
--- a/src/components/KanbanBoard.tsx
+++ b/src/components/KanbanBoard.tsx
@@ -266,7 +266,8 @@ const KanbanColumn = ({
   onUpdateTaskDueDate,
   areas,
   projects,
-  onProjectAssignment
+  onProjectAssignment,
+  selectedTask
 }: {
   timeframe: "NOW" | "NEXT" | "LATER" | "SOMEDAY";
   tasks: Task[];
@@ -281,6 +282,7 @@ const KanbanColumn = ({
     area: string;
   }>;
   onProjectAssignment?: (task: Task, projectId: string) => void;
+  selectedTask?: Task | null;
 }) => {
   const [isDragOver, setIsDragOver] = useState(false);
 

--- a/src/components/KanbanBoard.tsx
+++ b/src/components/KanbanBoard.tsx
@@ -428,6 +428,7 @@ export function KanbanBoard({
             areas={areas}
             projects={projects}
             onProjectAssignment={onProjectAssignment}
+            selectedTask={selectedTask}
           />
         ))}
       </div>

--- a/src/components/TaskDetailsSidebar.tsx
+++ b/src/components/TaskDetailsSidebar.tsx
@@ -161,8 +161,7 @@ export function TaskDetailsSidebar({
             <span className="text-sm text-muted-foreground w-20">Timeframe</span>
             <Select
               value={task.timeframe}
-              onValueChange={useCallback((value: string) =>
-                onUpdateTask({ timeframe: value as Task["timeframe"] }), [onUpdateTask])}
+              onValueChange={handleTimeframeChange}
             >
               <SelectTrigger className="w-auto h-auto p-0 border-none bg-transparent hover:bg-transparent focus:ring-0 focus:ring-offset-0 [&>svg]:hidden">
                 <span className={cn("text-xs px-2 py-1 rounded font-medium uppercase", getTimeframeColor(task.timeframe))}>

--- a/src/components/TaskDetailsSidebar.tsx
+++ b/src/components/TaskDetailsSidebar.tsx
@@ -305,7 +305,7 @@ export function TaskDetailsSidebar({
         <div className="border-t border-border mb-4"></div>
 
         {/* Tabs */}
-        <div className="flex border-b border-border mb-4">
+        <div className="flex mb-4">
           <button
             onClick={() => setActiveTab("description")}
             className={cn(

--- a/src/components/TaskDetailsSidebar.tsx
+++ b/src/components/TaskDetailsSidebar.tsx
@@ -88,6 +88,32 @@ export function TaskDetailsSidebar({
 }: TaskDetailsSidebarProps) {
   const [activeTab, setActiveTab] = useState<"description" | "activity">("description");
 
+  // Define all callbacks at the top level
+  const handleTitleChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) =>
+    onUpdateTask({ title: e.target.value }), [onUpdateTask]);
+
+  const handleToggleComplete = useCallback(() =>
+    onUpdateTask({ completed: task?.completed ? null : new Date() }),
+    [onUpdateTask, task?.completed]);
+
+  const handleTimeframeChange = useCallback((value: string) =>
+    onUpdateTask({ timeframe: value as Task["timeframe"] }), [onUpdateTask]);
+
+  const handlePriorityChange = useCallback((value: string) =>
+    onUpdateTask({ priority: value as Task["priority"] }), [onUpdateTask]);
+
+  const handleProjectChange = useCallback((value: string) => {
+    const projectId = value === "none" ? undefined : value;
+    const areaId = getAreaFromProject(projectId);
+    onUpdateTask({
+      project: projectId,
+      area: areaId
+    });
+  }, [onUpdateTask, getAreaFromProject]);
+
+  const handleDescriptionChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) =>
+    onUpdateTask({ description: e.target.value }), [onUpdateTask]);
+
   if (!isOpen || !task) {
     return null;
   }

--- a/src/components/TaskDetailsSidebar.tsx
+++ b/src/components/TaskDetailsSidebar.tsx
@@ -86,11 +86,11 @@ export function TaskDetailsSidebar({
   areas,
   getAreaFromProject
 }: TaskDetailsSidebarProps) {
+  const [activeTab, setActiveTab] = useState<"description" | "activity">("description");
+
   if (!isOpen || !task) {
     return null;
   }
-
-  const [activeTab, setActiveTab] = useState<"description" | "activity">("description");
 
   return (
     <div className="fixed right-0 top-0 h-full w-96 bg-white border-l border-border z-50 overflow-hidden flex flex-col">

--- a/src/components/TaskDetailsSidebar.tsx
+++ b/src/components/TaskDetailsSidebar.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import { Calendar } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";

--- a/src/components/TaskDetailsSidebar.tsx
+++ b/src/components/TaskDetailsSidebar.tsx
@@ -77,16 +77,8 @@ export function TaskDetailsSidebar({
 
   return (
     <div className="fixed right-0 top-0 h-full w-96 bg-white border-l border-border z-50 overflow-hidden flex flex-col">
-      {/* Header */}
-      <div className="flex items-center justify-between p-4 border-b border-border">
-        <div className="flex items-center gap-3 flex-1 min-w-0">
-          <Input
-            value={task.title}
-            onChange={useCallback((e: React.ChangeEvent<HTMLInputElement>) => 
-              onUpdateTask({ title: e.target.value }), [onUpdateTask])}
-            className="text-lg font-semibold border-none p-0 h-auto focus-visible:ring-0 bg-transparent"
-          />
-        </div>
+      {/* Header with close button only */}
+      <div className="flex items-center justify-end p-4 border-b border-border">
         <Button
           variant="ghost"
           size="sm"
@@ -102,22 +94,31 @@ export function TaskDetailsSidebar({
       </div>
 
       {/* Content */}
-      <div className="flex-1 overflow-y-auto p-4 space-y-6">
-        {/* Status and Priority Row */}
-        <div className="flex items-center gap-4">
-          <div className="flex items-center gap-2">
-            <input
-              type="checkbox"
-              checked={task.completed !== null}
-              className={cn("w-4 h-4 text-primary rounded border-border focus:ring-primary", 
-                getPriorityCheckboxColor(task.priority))}
-              onChange={useCallback(() => 
-                onUpdateTask({ completed: task.completed ? null : new Date() }), 
-                [onUpdateTask, task.completed])}
-            />
-          </div>
+      <div className="flex-1 overflow-y-auto p-4 space-y-4">
+        {/* Title and checkbox row */}
+        <div className="flex items-center gap-3">
+          <input
+            type="checkbox"
+            checked={task.completed !== null}
+            className={cn("w-4 h-4 text-primary rounded border-border focus:ring-primary",
+              getPriorityCheckboxColor(task.priority))}
+            onChange={useCallback(() =>
+              onUpdateTask({ completed: task.completed ? null : new Date() }),
+              [onUpdateTask, task.completed])}
+          />
+          <Input
+            value={task.title}
+            onChange={useCallback((e: React.ChangeEvent<HTMLInputElement>) =>
+              onUpdateTask({ title: e.target.value }), [onUpdateTask])}
+            className="text-lg font-semibold border-none p-0 h-auto focus-visible:ring-0 bg-transparent flex-1"
+          />
+        </div>
 
-          <div className="flex items-center gap-2">
+        {/* Properties with left-right layout */}
+        <div className="space-y-3">
+          {/* Priority */}
+          <div className="flex items-center justify-between">
+            <span className="text-sm font-medium text-foreground">Priority</span>
             <Select
               value={task.priority}
               onValueChange={useCallback((value: string) =>
@@ -180,123 +181,126 @@ export function TaskDetailsSidebar({
               </SelectContent>
             </Select>
           </div>
+
+          {/* Timeframe */}
+          <div className="flex items-center justify-between">
+            <span className="text-sm font-medium text-foreground">Timeframe</span>
+            <Select
+              value={task.timeframe}
+              onValueChange={useCallback((value: string) =>
+                onUpdateTask({ timeframe: value as Task["timeframe"] }), [onUpdateTask])}
+            >
+              <SelectTrigger className="w-24">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="NOW">Now</SelectItem>
+                <SelectItem value="NEXT">Next</SelectItem>
+                <SelectItem value="LATER">Later</SelectItem>
+                <SelectItem value="SOMEDAY">Someday</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Due Date */}
+          <div className="flex items-center justify-between">
+            <span className="text-sm font-medium text-foreground">Due Date</span>
+            <TaskDateTimePicker
+              date={task.dueDate}
+              onDateChange={useCallback((date: Date | undefined) =>
+                onUpdateTask({ dueDate: date }), [onUpdateTask])}
+              placeholder="Pick a date"
+              align="center"
+              side="left"
+              allowClear={true}
+            />
+          </div>
+
+          {/* Project */}
+          <div className="flex items-center justify-between">
+            <span className="text-sm font-medium text-foreground">Project</span>
+            <Select
+              value={task.project || "none"}
+              onValueChange={useCallback((value: string) => {
+                const projectId = value === "none" ? undefined : value;
+                const areaId = getAreaFromProject(projectId);
+                onUpdateTask({
+                  project: projectId,
+                  area: areaId
+                });
+              }, [onUpdateTask, getAreaFromProject])}
+            >
+              <SelectTrigger className="w-32">
+                <SelectValue placeholder="Select project" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="none">No project</SelectItem>
+                {projects.map((project) => (
+                  <SelectItem key={project.id} value={project.id}>
+                    {project.title}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Area */}
+          <div className="flex items-center justify-between">
+            <span className="text-sm font-medium text-foreground">Area</span>
+            <div className="flex items-center gap-2">
+              {getAreaFromProject(task.project) ? (
+                <span className={cn(
+                  "text-xs text-white px-2 py-1 rounded",
+                  areas.find(a => a.id === getAreaFromProject(task.project))?.color || "bg-muted"
+                )}>
+                  {areas.find(a => a.id === getAreaFromProject(task.project))?.name}
+                </span>
+              ) : (
+                <span className="text-sm text-muted-foreground">No area</span>
+              )}
+            </div>
+          </div>
+
+          {/* Completed Date (if task is completed) */}
+          {task.completed !== null && (
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium text-foreground">Completed</span>
+              <span className="text-sm text-muted-foreground">
+                {formatDateTime(task.completed)}
+              </span>
+            </div>
+          )}
         </div>
+
+        {/* Divider */}
+        <div className="border-t border-border my-4"></div>
 
         {/* Description */}
         <div>
           <h4 className="text-sm font-medium text-foreground mb-2">Description</h4>
           <Textarea
             value={task.description || ""}
-            onChange={useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => 
+            onChange={useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) =>
               onUpdateTask({ description: e.target.value }), [onUpdateTask])}
             placeholder="Enter task description"
             rows={3}
           />
         </div>
 
-        {/* Due Date */}
-        <div>
-          <h4 className="text-sm font-medium text-foreground mb-2">Due Date</h4>
-          <TaskDateTimePicker
-            date={task.dueDate}
-            onDateChange={useCallback((date: Date | undefined) => 
-              onUpdateTask({ dueDate: date }), [onUpdateTask])}
-            placeholder="Pick a date"
-            align="center"
-            side="left"
-            allowClear={true}
-          />
-        </div>
-
-        {/* Timeframe */}
-        <div>
-          <h4 className="text-sm font-medium text-foreground mb-2">Timeframe</h4>
-          <Select
-            value={task.timeframe}
-            onValueChange={useCallback((value: string) => 
-              onUpdateTask({ timeframe: value as Task["timeframe"] }), [onUpdateTask])}
-          >
-            <SelectTrigger>
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="NOW">Now</SelectItem>
-              <SelectItem value="NEXT">Next</SelectItem>
-              <SelectItem value="LATER">Later</SelectItem>
-              <SelectItem value="SOMEDAY">Someday</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
-
-        {/* Project */}
-        <div>
-          <h4 className="text-sm font-medium text-foreground mb-2">Project</h4>
-          <Select
-            value={task.project || "none"}
-            onValueChange={useCallback((value: string) => {
-              const projectId = value === "none" ? undefined : value;
-              const areaId = getAreaFromProject(projectId);
-              onUpdateTask({
-                project: projectId,
-                area: areaId
-              });
-            }, [onUpdateTask, getAreaFromProject])}
-          >
-            <SelectTrigger>
-              <SelectValue placeholder="Select project" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="none">No project</SelectItem>
-              {projects.map((project) => (
-                <SelectItem key={project.id} value={project.id}>
-                  {project.title}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-
-        {/* Area (read-only, derived from project) */}
-        <div>
-          <h4 className="text-sm font-medium text-foreground mb-2">Area</h4>
-          <div className="flex items-center gap-2">
-            {getAreaFromProject(task.project) ? (
-              <span className={cn(
-                "text-xs text-white px-2 py-1 rounded",
-                areas.find(a => a.id === getAreaFromProject(task.project))?.color || "bg-muted"
-              )}>
-                {areas.find(a => a.id === getAreaFromProject(task.project))?.name}
-              </span>
-            ) : (
-              <span className="text-sm text-muted-foreground">No area (no project assigned)</span>
-            )}
-          </div>
-        </div>
-
-        {/* Created Date */}
-        <div>
-          <h4 className="text-sm font-medium text-foreground mb-2">Created</h4>
-          <span className="text-sm text-muted-foreground">
-            {formatDateTime(task.created)}
-          </span>
-        </div>
-
-        {/* Completed Date */}
-        {task.completed !== null && (
-          <div>
-            <h4 className="text-sm font-medium text-foreground mb-2">Completed</h4>
-            <span className="text-sm text-muted-foreground">
-              {formatDateTime(task.completed)}
+        {/* Bottom row: Created and Task ID */}
+        <div className="flex items-center justify-between pt-4 mt-auto">
+          <div className="flex flex-col">
+            <span className="text-xs font-medium text-foreground">Created</span>
+            <span className="text-xs text-muted-foreground">
+              {formatDateTime(task.created)}
             </span>
           </div>
-        )}
-
-        {/* Task ID */}
-        <div>
-          <h4 className="text-sm font-medium text-foreground mb-2">Task ID</h4>
-          <code className="text-xs bg-muted text-muted-foreground px-2 py-1 rounded font-mono">
-            {task.id}
-          </code>
+          <div className="flex flex-col items-end">
+            <span className="text-xs font-medium text-foreground">Task ID</span>
+            <code className="text-xs bg-muted text-muted-foreground px-2 py-1 rounded font-mono">
+              {task.id}
+            </code>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/TaskDetailsSidebar.tsx
+++ b/src/components/TaskDetailsSidebar.tsx
@@ -145,14 +145,11 @@ export function TaskDetailsSidebar({
             checked={task.completed !== null}
             className={cn("w-4 h-4 text-primary rounded border-border focus:ring-primary",
               getPriorityCheckboxColor(task.priority))}
-            onChange={useCallback(() =>
-              onUpdateTask({ completed: task.completed ? null : new Date() }),
-              [onUpdateTask, task.completed])}
+            onChange={handleToggleComplete}
           />
           <Input
             value={task.title}
-            onChange={useCallback((e: React.ChangeEvent<HTMLInputElement>) =>
-              onUpdateTask({ title: e.target.value }), [onUpdateTask])}
+            onChange={handleTitleChange}
             className="text-lg font-semibold border-none p-0 h-auto focus-visible:ring-0 bg-transparent flex-1"
           />
         </div>

--- a/src/components/TaskDetailsSidebar.tsx
+++ b/src/components/TaskDetailsSidebar.tsx
@@ -114,104 +114,100 @@ export function TaskDetailsSidebar({
           />
         </div>
 
-        {/* Properties with left-aligned layout */}
+        {/* Properties with horizontal layout */}
         <div className="space-y-3">
           {/* Timeframe */}
-          <div>
+          <div className="flex items-center justify-between">
             <span className="text-sm text-muted-foreground">Timeframe</span>
-            <div className="mt-1">
-              <Select
-                value={task.timeframe}
-                onValueChange={useCallback((value: string) =>
-                  onUpdateTask({ timeframe: value as Task["timeframe"] }), [onUpdateTask])}
-              >
-                <SelectTrigger className="w-auto h-auto p-0 border-none bg-transparent hover:bg-transparent focus:ring-0 focus:ring-offset-0 [&>svg]:hidden">
-                  <span className="text-sm font-medium text-foreground">
-                    {task.timeframe}
-                  </span>
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="NOW">NOW</SelectItem>
-                  <SelectItem value="NEXT">NEXT</SelectItem>
-                  <SelectItem value="LATER">LATER</SelectItem>
-                  <SelectItem value="SOMEDAY">SOMEDAY</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
+            <Select
+              value={task.timeframe}
+              onValueChange={useCallback((value: string) =>
+                onUpdateTask({ timeframe: value as Task["timeframe"] }), [onUpdateTask])}
+            >
+              <SelectTrigger className="w-auto h-auto p-0 border-none bg-transparent hover:bg-transparent focus:ring-0 focus:ring-offset-0 [&>svg]:hidden">
+                <span className="text-sm font-medium text-foreground">
+                  {task.timeframe}
+                </span>
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="NOW">NOW</SelectItem>
+                <SelectItem value="NEXT">NEXT</SelectItem>
+                <SelectItem value="LATER">LATER</SelectItem>
+                <SelectItem value="SOMEDAY">SOMEDAY</SelectItem>
+              </SelectContent>
+            </Select>
           </div>
 
           {/* Priority */}
-          <div>
+          <div className="flex items-center justify-between">
             <span className="text-sm text-muted-foreground">Priority</span>
-            <div className="mt-1">
-              <Select
-                value={task.priority}
-                onValueChange={useCallback((value: string) =>
-                  onUpdateTask({ priority: value as Task["priority"] }), [onUpdateTask])}
-              >
-                <SelectTrigger className="w-auto h-auto p-0 border-none bg-transparent hover:bg-transparent focus:ring-0 focus:ring-offset-0 [&>svg]:hidden">
-                  <img
-                    src="https://cdn.builder.io/api/v1/image/assets%2F871cdad99f0e4f7383e2724856d9c17b%2F63cf4952854846e5994e15d4c2b9fc7e?format=webp&width=800"
-                    alt="Priority flag"
-                    className="w-5 h-5"
-                    style={{
-                      filter: task.priority === "urgent"
-                        ? "brightness(0) saturate(100%) invert(18%) sepia(95%) saturate(7434%) hue-rotate(2deg) brightness(102%) contrast(107%)"
-                        : task.priority === "medium"
-                        ? "brightness(0) saturate(100%) invert(70%) sepia(70%) saturate(421%) hue-rotate(13deg) brightness(104%) contrast(94%)"
-                        : "brightness(0) saturate(100%) invert(47%) sepia(96%) saturate(1288%) hue-rotate(204deg) brightness(97%) contrast(94%)"
-                    }}
-                  />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="low">
-                    <div className="flex items-center gap-2">
-                      <img
-                        src="https://cdn.builder.io/api/v1/image/assets%2F871cdad99f0e4f7383e2724856d9c17b%2F63cf4952854846e5994e15d4c2b9fc7e?format=webp&width=800"
-                        alt="Low priority"
-                        className="w-4 h-4"
-                        style={{
-                          filter: "brightness(0) saturate(100%) invert(47%) sepia(96%) saturate(1288%) hue-rotate(204deg) brightness(97%) contrast(94%)"
-                        }}
-                      />
-                      <span>Low</span>
-                    </div>
-                  </SelectItem>
-                  <SelectItem value="medium">
-                    <div className="flex items-center gap-2">
-                      <img
-                        src="https://cdn.builder.io/api/v1/image/assets%2F871cdad99f0e4f7383e2724856d9c17b%2F63cf4952854846e5994e15d4c2b9fc7e?format=webp&width=800"
-                        alt="Medium priority"
-                        className="w-4 h-4"
-                        style={{
-                          filter: "brightness(0) saturate(100%) invert(70%) sepia(70%) saturate(421%) hue-rotate(13deg) brightness(104%) contrast(94%)"
-                        }}
-                      />
-                      <span>Medium</span>
-                    </div>
-                  </SelectItem>
-                  <SelectItem value="urgent">
-                    <div className="flex items-center gap-2">
-                      <img
-                        src="https://cdn.builder.io/api/v1/image/assets%2F871cdad99f0e4f7383e2724856d9c17b%2F63cf4952854846e5994e15d4c2b9fc7e?format=webp&width=800"
-                        alt="High priority"
-                        className="w-4 h-4"
-                        style={{
-                          filter: "brightness(0) saturate(100%) invert(18%) sepia(95%) saturate(7434%) hue-rotate(2deg) brightness(102%) contrast(107%)"
-                        }}
-                      />
-                      <span>High</span>
-                    </div>
-                  </SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
+            <Select
+              value={task.priority}
+              onValueChange={useCallback((value: string) =>
+                onUpdateTask({ priority: value as Task["priority"] }), [onUpdateTask])}
+            >
+              <SelectTrigger className="w-auto h-auto p-0 border-none bg-transparent hover:bg-transparent focus:ring-0 focus:ring-offset-0 [&>svg]:hidden">
+                <img
+                  src="https://cdn.builder.io/api/v1/image/assets%2F871cdad99f0e4f7383e2724856d9c17b%2F63cf4952854846e5994e15d4c2b9fc7e?format=webp&width=800"
+                  alt="Priority flag"
+                  className="w-5 h-5"
+                  style={{
+                    filter: task.priority === "urgent"
+                      ? "brightness(0) saturate(100%) invert(18%) sepia(95%) saturate(7434%) hue-rotate(2deg) brightness(102%) contrast(107%)"
+                      : task.priority === "medium"
+                      ? "brightness(0) saturate(100%) invert(70%) sepia(70%) saturate(421%) hue-rotate(13deg) brightness(104%) contrast(94%)"
+                      : "brightness(0) saturate(100%) invert(47%) sepia(96%) saturate(1288%) hue-rotate(204deg) brightness(97%) contrast(94%)"
+                  }}
+                />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="low">
+                  <div className="flex items-center gap-2">
+                    <img
+                      src="https://cdn.builder.io/api/v1/image/assets%2F871cdad99f0e4f7383e2724856d9c17b%2F63cf4952854846e5994e15d4c2b9fc7e?format=webp&width=800"
+                      alt="Low priority"
+                      className="w-4 h-4"
+                      style={{
+                        filter: "brightness(0) saturate(100%) invert(47%) sepia(96%) saturate(1288%) hue-rotate(204deg) brightness(97%) contrast(94%)"
+                      }}
+                    />
+                    <span>Low</span>
+                  </div>
+                </SelectItem>
+                <SelectItem value="medium">
+                  <div className="flex items-center gap-2">
+                    <img
+                      src="https://cdn.builder.io/api/v1/image/assets%2F871cdad99f0e4f7383e2724856d9c17b%2F63cf4952854846e5994e15d4c2b9fc7e?format=webp&width=800"
+                      alt="Medium priority"
+                      className="w-4 h-4"
+                      style={{
+                        filter: "brightness(0) saturate(100%) invert(70%) sepia(70%) saturate(421%) hue-rotate(13deg) brightness(104%) contrast(94%)"
+                      }}
+                    />
+                    <span>Medium</span>
+                  </div>
+                </SelectItem>
+                <SelectItem value="urgent">
+                  <div className="flex items-center gap-2">
+                    <img
+                      src="https://cdn.builder.io/api/v1/image/assets%2F871cdad99f0e4f7383e2724856d9c17b%2F63cf4952854846e5994e15d4c2b9fc7e?format=webp&width=800"
+                      alt="High priority"
+                      className="w-4 h-4"
+                      style={{
+                        filter: "brightness(0) saturate(100%) invert(18%) sepia(95%) saturate(7434%) hue-rotate(2deg) brightness(102%) contrast(107%)"
+                      }}
+                    />
+                    <span>High</span>
+                  </div>
+                </SelectItem>
+              </SelectContent>
+            </Select>
           </div>
 
           {/* Area */}
-          <div>
+          <div className="flex items-center justify-between">
             <span className="text-sm text-muted-foreground">Area</span>
-            <div className="mt-1">
+            <div>
               {getAreaFromProject(task.project) ? (
                 <span className={cn(
                   "text-xs text-white px-2 py-1 rounded",
@@ -226,62 +222,56 @@ export function TaskDetailsSidebar({
           </div>
 
           {/* Project */}
-          <div>
+          <div className="flex items-center justify-between">
             <span className="text-sm text-muted-foreground">Project</span>
-            <div className="mt-1">
-              <Select
-                value={task.project || "none"}
-                onValueChange={useCallback((value: string) => {
-                  const projectId = value === "none" ? undefined : value;
-                  const areaId = getAreaFromProject(projectId);
-                  onUpdateTask({
-                    project: projectId,
-                    area: areaId
-                  });
-                }, [onUpdateTask, getAreaFromProject])}
-              >
-                <SelectTrigger className="w-auto h-auto p-0 border-none bg-transparent hover:bg-transparent focus:ring-0 focus:ring-offset-0 [&>svg]:hidden">
-                  <span className="text-sm font-medium text-foreground">
-                    {task.project ? projects.find(p => p.id === task.project)?.title || 'Unknown Project' : 'No project'}
-                  </span>
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="none">No project</SelectItem>
-                  {projects.map((project) => (
-                    <SelectItem key={project.id} value={project.id}>
-                      {project.title}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
+            <Select
+              value={task.project || "none"}
+              onValueChange={useCallback((value: string) => {
+                const projectId = value === "none" ? undefined : value;
+                const areaId = getAreaFromProject(projectId);
+                onUpdateTask({
+                  project: projectId,
+                  area: areaId
+                });
+              }, [onUpdateTask, getAreaFromProject])}
+            >
+              <SelectTrigger className="w-auto h-auto p-0 border-none bg-transparent hover:bg-transparent focus:ring-0 focus:ring-offset-0 [&>svg]:hidden">
+                <span className="text-sm font-medium text-foreground">
+                  {task.project ? projects.find(p => p.id === task.project)?.title || 'Unknown Project' : 'No project'}
+                </span>
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="none">No project</SelectItem>
+                {projects.map((project) => (
+                  <SelectItem key={project.id} value={project.id}>
+                    {project.title}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
 
           {/* Due Date */}
-          <div>
+          <div className="flex items-center justify-between">
             <span className="text-sm text-muted-foreground">Due Date</span>
-            <div className="mt-1">
-              <TaskDateTimePicker
-                date={task.dueDate}
-                onDateChange={useCallback((date: Date | undefined) =>
-                  onUpdateTask({ dueDate: date }), [onUpdateTask])}
-                placeholder="Pick a date"
-                align="start"
-                side="left"
-                allowClear={true}
-              />
-            </div>
+            <TaskDateTimePicker
+              date={task.dueDate}
+              onDateChange={useCallback((date: Date | undefined) =>
+                onUpdateTask({ dueDate: date }), [onUpdateTask])}
+              placeholder="Pick a date"
+              align="start"
+              side="left"
+              allowClear={true}
+            />
           </div>
 
           {/* Completed Date (if task is completed) */}
           {task.completed !== null && (
-            <div>
+            <div className="flex items-center justify-between">
               <span className="text-sm text-muted-foreground">Completed</span>
-              <div className="mt-1">
-                <span className="text-sm font-medium text-foreground">
-                  {formatDateTime(task.completed)}
-                </span>
-              </div>
+              <span className="text-sm font-medium text-foreground">
+                {formatDateTime(task.completed)}
+              </span>
             </div>
           )}
         </div>

--- a/src/components/TaskDetailsSidebar.tsx
+++ b/src/components/TaskDetailsSidebar.tsx
@@ -336,9 +336,8 @@ export function TaskDetailsSidebar({
             <Textarea
               value={task.description || ""}
               onChange={handleDescriptionChange}
-              placeholder="Enter task description"
               rows={3}
-              className="min-h-[100px]"
+              className="min-h-[100px] bg-transparent border-none focus-visible:ring-0 focus-visible:ring-offset-0 px-0 py-0"
             />
           ) : (
             <div className="text-sm text-muted-foreground">

--- a/src/components/TaskDetailsSidebar.tsx
+++ b/src/components/TaskDetailsSidebar.tsx
@@ -123,49 +123,57 @@ export function TaskDetailsSidebar({
               onValueChange={useCallback((value: string) =>
                 onUpdateTask({ priority: value as Task["priority"] }), [onUpdateTask])}
             >
-              <SelectTrigger className="w-auto h-auto p-0 border-none bg-transparent hover:bg-transparent focus:ring-0 focus:ring-offset-0">
-                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path
-                    d="M6 4L18 4C18.5523 4 19 4.44772 19 5V19C19 19.5523 18.5523 20 18 20H6C5.44772 20 5 19.5523 5 19V5C5 4.44772 5.44772 4 6 4Z"
-                    fill={
-                      task.priority === "urgent" ? "#ef4444" :
-                      task.priority === "medium" ? "#eab308" :
-                      "#3b82f6"
-                    }
-                  />
-                </svg>
+              <SelectTrigger className="w-auto h-auto p-0 border-none bg-transparent hover:bg-transparent focus:ring-0 focus:ring-offset-0 [&>svg]:hidden">
+                <img
+                  src="https://cdn.builder.io/api/v1/image/assets%2F871cdad99f0e4f7383e2724856d9c17b%2F63cf4952854846e5994e15d4c2b9fc7e?format=webp&width=800"
+                  alt="Priority flag"
+                  className="w-6 h-6"
+                  style={{
+                    filter: task.priority === "urgent"
+                      ? "brightness(0) saturate(100%) invert(18%) sepia(95%) saturate(7434%) hue-rotate(2deg) brightness(102%) contrast(107%)"
+                      : task.priority === "medium"
+                      ? "brightness(0) saturate(100%) invert(70%) sepia(70%) saturate(421%) hue-rotate(13deg) brightness(104%) contrast(94%)"
+                      : "brightness(0) saturate(100%) invert(47%) sepia(96%) saturate(1288%) hue-rotate(204deg) brightness(97%) contrast(94%)"
+                  }}
+                />
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="low">
                   <div className="flex items-center gap-2">
-                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                      <path
-                        d="M6 4L18 4C18.5523 4 19 4.44772 19 5V19C19 19.5523 18.5523 20 18 20H6C5.44772 20 5 19.5523 5 19V5C5 4.44772 5.44772 4 6 4Z"
-                        fill="#3b82f6"
-                      />
-                    </svg>
+                    <img
+                      src="https://cdn.builder.io/api/v1/image/assets%2F871cdad99f0e4f7383e2724856d9c17b%2F63cf4952854846e5994e15d4c2b9fc7e?format=webp&width=800"
+                      alt="Low priority"
+                      className="w-4 h-4"
+                      style={{
+                        filter: "brightness(0) saturate(100%) invert(47%) sepia(96%) saturate(1288%) hue-rotate(204deg) brightness(97%) contrast(94%)"
+                      }}
+                    />
                     <span>Low</span>
                   </div>
                 </SelectItem>
                 <SelectItem value="medium">
                   <div className="flex items-center gap-2">
-                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                      <path
-                        d="M6 4L18 4C18.5523 4 19 4.44772 19 5V19C19 19.5523 18.5523 20 18 20H6C5.44772 20 5 19.5523 5 19V5C5 4.44772 5.44772 4 6 4Z"
-                        fill="#eab308"
-                      />
-                    </svg>
+                    <img
+                      src="https://cdn.builder.io/api/v1/image/assets%2F871cdad99f0e4f7383e2724856d9c17b%2F63cf4952854846e5994e15d4c2b9fc7e?format=webp&width=800"
+                      alt="Medium priority"
+                      className="w-4 h-4"
+                      style={{
+                        filter: "brightness(0) saturate(100%) invert(70%) sepia(70%) saturate(421%) hue-rotate(13deg) brightness(104%) contrast(94%)"
+                      }}
+                    />
                     <span>Medium</span>
                   </div>
                 </SelectItem>
                 <SelectItem value="urgent">
                   <div className="flex items-center gap-2">
-                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                      <path
-                        d="M6 4L18 4C18.5523 4 19 4.44772 19 5V19C19 19.5523 18.5523 20 18 20H6C5.44772 20 5 19.5523 5 19V5C5 4.44772 5.44772 4 6 4Z"
-                        fill="#ef4444"
-                      />
-                    </svg>
+                    <img
+                      src="https://cdn.builder.io/api/v1/image/assets%2F871cdad99f0e4f7383e2724856d9c17b%2F63cf4952854846e5994e15d4c2b9fc7e?format=webp&width=800"
+                      alt="High priority"
+                      className="w-4 h-4"
+                      style={{
+                        filter: "brightness(0) saturate(100%) invert(18%) sepia(95%) saturate(7434%) hue-rotate(2deg) brightness(102%) contrast(107%)"
+                      }}
+                    />
                     <span>High</span>
                   </div>
                 </SelectItem>

--- a/src/components/TaskDetailsSidebar.tsx
+++ b/src/components/TaskDetailsSidebar.tsx
@@ -182,8 +182,7 @@ export function TaskDetailsSidebar({
             <span className="text-sm text-muted-foreground w-20">Priority</span>
             <Select
               value={task.priority}
-              onValueChange={useCallback((value: string) =>
-                onUpdateTask({ priority: value as Task["priority"] }), [onUpdateTask])}
+              onValueChange={handlePriorityChange}
             >
               <SelectTrigger className="w-auto h-auto p-0 border-none bg-transparent hover:bg-transparent focus:ring-0 focus:ring-offset-0 [&>svg]:hidden">
                 <img

--- a/src/components/TaskDetailsSidebar.tsx
+++ b/src/components/TaskDetailsSidebar.tsx
@@ -347,21 +347,6 @@ export function TaskDetailsSidebar({
           )}
         </div>
 
-        {/* Bottom row: Created and Task ID - Fixed at bottom */}
-        <div className="flex items-center justify-between pt-4 mt-auto border-t border-border">
-          <div className="flex flex-col">
-            <span className="text-xs font-medium text-foreground">Created</span>
-            <span className="text-xs text-muted-foreground">
-              {formatDateTime(task.created)}
-            </span>
-          </div>
-          <div className="flex flex-col items-end">
-            <span className="text-xs font-medium text-foreground">Task ID</span>
-            <code className="text-xs bg-muted text-muted-foreground px-2 py-1 rounded font-mono">
-              {task.id}
-            </code>
-          </div>
-        </div>
       </div>
     </div>
   );

--- a/src/components/TaskDetailsSidebar.tsx
+++ b/src/components/TaskDetailsSidebar.tsx
@@ -86,6 +86,8 @@ export function TaskDetailsSidebar({
   areas,
   getAreaFromProject
 }: TaskDetailsSidebarProps) {
+  const [activeTab, setActiveTab] = useState<"description" | "activity">("description");
+
   if (!isOpen || !task) {
     return null;
   }

--- a/src/components/TaskDetailsSidebar.tsx
+++ b/src/components/TaskDetailsSidebar.tsx
@@ -115,13 +115,9 @@ export function TaskDetailsSidebar({
                 onUpdateTask({ completed: task.completed ? null : new Date() }), 
                 [onUpdateTask, task.completed])}
             />
-            <span className="text-sm font-medium">
-              {task.completed !== null ? "Completed" : "Pending"}
-            </span>
           </div>
 
           <div className="flex items-center gap-2">
-            <span className="text-sm text-muted-foreground">Priority:</span>
             <Select
               value={task.priority}
               onValueChange={useCallback((value: string) => 

--- a/src/components/TaskDetailsSidebar.tsx
+++ b/src/components/TaskDetailsSidebar.tsx
@@ -264,14 +264,7 @@ export function TaskDetailsSidebar({
             <span className="text-sm text-muted-foreground w-20">Project</span>
             <Select
               value={task.project || "none"}
-              onValueChange={useCallback((value: string) => {
-                const projectId = value === "none" ? undefined : value;
-                const areaId = getAreaFromProject(projectId);
-                onUpdateTask({
-                  project: projectId,
-                  area: areaId
-                });
-              }, [onUpdateTask, getAreaFromProject])}
+              onValueChange={handleProjectChange}
             >
               <SelectTrigger className="w-auto h-auto p-0 border-none bg-transparent hover:bg-transparent focus:ring-0 focus:ring-offset-0 [&>svg]:hidden">
                 <span className="text-sm font-medium text-foreground">

--- a/src/components/TaskDetailsSidebar.tsx
+++ b/src/components/TaskDetailsSidebar.tsx
@@ -117,8 +117,8 @@ export function TaskDetailsSidebar({
         {/* Properties with horizontal layout */}
         <div className="space-y-3">
           {/* Timeframe */}
-          <div className="flex items-center justify-between">
-            <span className="text-sm text-muted-foreground">Timeframe</span>
+          <div className="flex items-center">
+            <span className="text-sm text-muted-foreground w-20">Timeframe</span>
             <Select
               value={task.timeframe}
               onValueChange={useCallback((value: string) =>
@@ -139,8 +139,8 @@ export function TaskDetailsSidebar({
           </div>
 
           {/* Priority */}
-          <div className="flex items-center justify-between">
-            <span className="text-sm text-muted-foreground">Priority</span>
+          <div className="flex items-center">
+            <span className="text-sm text-muted-foreground w-20">Priority</span>
             <Select
               value={task.priority}
               onValueChange={useCallback((value: string) =>
@@ -205,8 +205,8 @@ export function TaskDetailsSidebar({
           </div>
 
           {/* Area */}
-          <div className="flex items-center justify-between">
-            <span className="text-sm text-muted-foreground">Area</span>
+          <div className="flex items-center">
+            <span className="text-sm text-muted-foreground w-20">Area</span>
             <div>
               {getAreaFromProject(task.project) ? (
                 <span className={cn(
@@ -222,8 +222,8 @@ export function TaskDetailsSidebar({
           </div>
 
           {/* Project */}
-          <div className="flex items-center justify-between">
-            <span className="text-sm text-muted-foreground">Project</span>
+          <div className="flex items-center">
+            <span className="text-sm text-muted-foreground w-20">Project</span>
             <Select
               value={task.project || "none"}
               onValueChange={useCallback((value: string) => {
@@ -252,8 +252,8 @@ export function TaskDetailsSidebar({
           </div>
 
           {/* Due Date */}
-          <div className="flex items-center justify-between">
-            <span className="text-sm text-muted-foreground">Due Date</span>
+          <div className="flex items-center">
+            <span className="text-sm text-muted-foreground w-20">Due Date</span>
             <TaskDateTimePicker
               date={task.dueDate}
               onDateChange={useCallback((date: Date | undefined) =>
@@ -267,8 +267,8 @@ export function TaskDetailsSidebar({
 
           {/* Completed Date (if task is completed) */}
           {task.completed !== null && (
-            <div className="flex items-center justify-between">
-              <span className="text-sm text-muted-foreground">Completed</span>
+            <div className="flex items-center">
+              <span className="text-sm text-muted-foreground w-20">Completed</span>
               <span className="text-sm font-medium text-foreground">
                 {formatDateTime(task.completed)}
               </span>

--- a/src/components/TaskDetailsSidebar.tsx
+++ b/src/components/TaskDetailsSidebar.tsx
@@ -62,6 +62,21 @@ const getPriorityCheckboxColor = (priority: string) => {
   }
 };
 
+const getTimeframeColor = (timeframe: string) => {
+  switch (timeframe) {
+    case "NOW":
+      return "bg-red-500 text-white";
+    case "NEXT":
+      return "bg-amber-500 text-white";
+    case "LATER":
+      return "bg-blue-500 text-white";
+    case "SOMEDAY":
+      return "bg-green-500 text-white";
+    default:
+      return "bg-muted text-muted-foreground";
+  }
+};
+
 export function TaskDetailsSidebar({
   isOpen,
   task,

--- a/src/components/TaskDetailsSidebar.tsx
+++ b/src/components/TaskDetailsSidebar.tsx
@@ -114,140 +114,104 @@ export function TaskDetailsSidebar({
           />
         </div>
 
-        {/* Properties with left-right layout */}
+        {/* Properties with left-aligned layout */}
         <div className="space-y-3">
-          {/* Priority */}
-          <div className="flex items-center justify-between">
-            <span className="text-sm font-medium text-foreground">Priority</span>
-            <Select
-              value={task.priority}
-              onValueChange={useCallback((value: string) =>
-                onUpdateTask({ priority: value as Task["priority"] }), [onUpdateTask])}
-            >
-              <SelectTrigger className="w-auto h-auto p-0 border-none bg-transparent hover:bg-transparent focus:ring-0 focus:ring-offset-0 [&>svg]:hidden">
-                <img
-                  src="https://cdn.builder.io/api/v1/image/assets%2F871cdad99f0e4f7383e2724856d9c17b%2F63cf4952854846e5994e15d4c2b9fc7e?format=webp&width=800"
-                  alt="Priority flag"
-                  className="w-6 h-6"
-                  style={{
-                    filter: task.priority === "urgent"
-                      ? "brightness(0) saturate(100%) invert(18%) sepia(95%) saturate(7434%) hue-rotate(2deg) brightness(102%) contrast(107%)"
-                      : task.priority === "medium"
-                      ? "brightness(0) saturate(100%) invert(70%) sepia(70%) saturate(421%) hue-rotate(13deg) brightness(104%) contrast(94%)"
-                      : "brightness(0) saturate(100%) invert(47%) sepia(96%) saturate(1288%) hue-rotate(204deg) brightness(97%) contrast(94%)"
-                  }}
-                />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="low">
-                  <div className="flex items-center gap-2">
-                    <img
-                      src="https://cdn.builder.io/api/v1/image/assets%2F871cdad99f0e4f7383e2724856d9c17b%2F63cf4952854846e5994e15d4c2b9fc7e?format=webp&width=800"
-                      alt="Low priority"
-                      className="w-4 h-4"
-                      style={{
-                        filter: "brightness(0) saturate(100%) invert(47%) sepia(96%) saturate(1288%) hue-rotate(204deg) brightness(97%) contrast(94%)"
-                      }}
-                    />
-                    <span>Low</span>
-                  </div>
-                </SelectItem>
-                <SelectItem value="medium">
-                  <div className="flex items-center gap-2">
-                    <img
-                      src="https://cdn.builder.io/api/v1/image/assets%2F871cdad99f0e4f7383e2724856d9c17b%2F63cf4952854846e5994e15d4c2b9fc7e?format=webp&width=800"
-                      alt="Medium priority"
-                      className="w-4 h-4"
-                      style={{
-                        filter: "brightness(0) saturate(100%) invert(70%) sepia(70%) saturate(421%) hue-rotate(13deg) brightness(104%) contrast(94%)"
-                      }}
-                    />
-                    <span>Medium</span>
-                  </div>
-                </SelectItem>
-                <SelectItem value="urgent">
-                  <div className="flex items-center gap-2">
-                    <img
-                      src="https://cdn.builder.io/api/v1/image/assets%2F871cdad99f0e4f7383e2724856d9c17b%2F63cf4952854846e5994e15d4c2b9fc7e?format=webp&width=800"
-                      alt="High priority"
-                      className="w-4 h-4"
-                      style={{
-                        filter: "brightness(0) saturate(100%) invert(18%) sepia(95%) saturate(7434%) hue-rotate(2deg) brightness(102%) contrast(107%)"
-                      }}
-                    />
-                    <span>High</span>
-                  </div>
-                </SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-
           {/* Timeframe */}
-          <div className="flex items-center justify-between">
-            <span className="text-sm font-medium text-foreground">Timeframe</span>
-            <Select
-              value={task.timeframe}
-              onValueChange={useCallback((value: string) =>
-                onUpdateTask({ timeframe: value as Task["timeframe"] }), [onUpdateTask])}
-            >
-              <SelectTrigger className="w-24">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="NOW">Now</SelectItem>
-                <SelectItem value="NEXT">Next</SelectItem>
-                <SelectItem value="LATER">Later</SelectItem>
-                <SelectItem value="SOMEDAY">Someday</SelectItem>
-              </SelectContent>
-            </Select>
+          <div>
+            <span className="text-sm text-muted-foreground">Timeframe</span>
+            <div className="mt-1">
+              <Select
+                value={task.timeframe}
+                onValueChange={useCallback((value: string) =>
+                  onUpdateTask({ timeframe: value as Task["timeframe"] }), [onUpdateTask])}
+              >
+                <SelectTrigger className="w-auto h-auto p-0 border-none bg-transparent hover:bg-transparent focus:ring-0 focus:ring-offset-0 [&>svg]:hidden">
+                  <span className="text-sm font-medium text-foreground">
+                    {task.timeframe}
+                  </span>
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="NOW">NOW</SelectItem>
+                  <SelectItem value="NEXT">NEXT</SelectItem>
+                  <SelectItem value="LATER">LATER</SelectItem>
+                  <SelectItem value="SOMEDAY">SOMEDAY</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
           </div>
 
-          {/* Due Date */}
-          <div className="flex items-center justify-between">
-            <span className="text-sm font-medium text-foreground">Due Date</span>
-            <TaskDateTimePicker
-              date={task.dueDate}
-              onDateChange={useCallback((date: Date | undefined) =>
-                onUpdateTask({ dueDate: date }), [onUpdateTask])}
-              placeholder="Pick a date"
-              align="center"
-              side="left"
-              allowClear={true}
-            />
-          </div>
-
-          {/* Project */}
-          <div className="flex items-center justify-between">
-            <span className="text-sm font-medium text-foreground">Project</span>
-            <Select
-              value={task.project || "none"}
-              onValueChange={useCallback((value: string) => {
-                const projectId = value === "none" ? undefined : value;
-                const areaId = getAreaFromProject(projectId);
-                onUpdateTask({
-                  project: projectId,
-                  area: areaId
-                });
-              }, [onUpdateTask, getAreaFromProject])}
-            >
-              <SelectTrigger className="w-32">
-                <SelectValue placeholder="Select project" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="none">No project</SelectItem>
-                {projects.map((project) => (
-                  <SelectItem key={project.id} value={project.id}>
-                    {project.title}
+          {/* Priority */}
+          <div>
+            <span className="text-sm text-muted-foreground">Priority</span>
+            <div className="mt-1">
+              <Select
+                value={task.priority}
+                onValueChange={useCallback((value: string) =>
+                  onUpdateTask({ priority: value as Task["priority"] }), [onUpdateTask])}
+              >
+                <SelectTrigger className="w-auto h-auto p-0 border-none bg-transparent hover:bg-transparent focus:ring-0 focus:ring-offset-0 [&>svg]:hidden">
+                  <img
+                    src="https://cdn.builder.io/api/v1/image/assets%2F871cdad99f0e4f7383e2724856d9c17b%2F63cf4952854846e5994e15d4c2b9fc7e?format=webp&width=800"
+                    alt="Priority flag"
+                    className="w-5 h-5"
+                    style={{
+                      filter: task.priority === "urgent"
+                        ? "brightness(0) saturate(100%) invert(18%) sepia(95%) saturate(7434%) hue-rotate(2deg) brightness(102%) contrast(107%)"
+                        : task.priority === "medium"
+                        ? "brightness(0) saturate(100%) invert(70%) sepia(70%) saturate(421%) hue-rotate(13deg) brightness(104%) contrast(94%)"
+                        : "brightness(0) saturate(100%) invert(47%) sepia(96%) saturate(1288%) hue-rotate(204deg) brightness(97%) contrast(94%)"
+                    }}
+                  />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="low">
+                    <div className="flex items-center gap-2">
+                      <img
+                        src="https://cdn.builder.io/api/v1/image/assets%2F871cdad99f0e4f7383e2724856d9c17b%2F63cf4952854846e5994e15d4c2b9fc7e?format=webp&width=800"
+                        alt="Low priority"
+                        className="w-4 h-4"
+                        style={{
+                          filter: "brightness(0) saturate(100%) invert(47%) sepia(96%) saturate(1288%) hue-rotate(204deg) brightness(97%) contrast(94%)"
+                        }}
+                      />
+                      <span>Low</span>
+                    </div>
                   </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+                  <SelectItem value="medium">
+                    <div className="flex items-center gap-2">
+                      <img
+                        src="https://cdn.builder.io/api/v1/image/assets%2F871cdad99f0e4f7383e2724856d9c17b%2F63cf4952854846e5994e15d4c2b9fc7e?format=webp&width=800"
+                        alt="Medium priority"
+                        className="w-4 h-4"
+                        style={{
+                          filter: "brightness(0) saturate(100%) invert(70%) sepia(70%) saturate(421%) hue-rotate(13deg) brightness(104%) contrast(94%)"
+                        }}
+                      />
+                      <span>Medium</span>
+                    </div>
+                  </SelectItem>
+                  <SelectItem value="urgent">
+                    <div className="flex items-center gap-2">
+                      <img
+                        src="https://cdn.builder.io/api/v1/image/assets%2F871cdad99f0e4f7383e2724856d9c17b%2F63cf4952854846e5994e15d4c2b9fc7e?format=webp&width=800"
+                        alt="High priority"
+                        className="w-4 h-4"
+                        style={{
+                          filter: "brightness(0) saturate(100%) invert(18%) sepia(95%) saturate(7434%) hue-rotate(2deg) brightness(102%) contrast(107%)"
+                        }}
+                      />
+                      <span>High</span>
+                    </div>
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
           </div>
 
           {/* Area */}
-          <div className="flex items-center justify-between">
-            <span className="text-sm font-medium text-foreground">Area</span>
-            <div className="flex items-center gap-2">
+          <div>
+            <span className="text-sm text-muted-foreground">Area</span>
+            <div className="mt-1">
               {getAreaFromProject(task.project) ? (
                 <span className={cn(
                   "text-xs text-white px-2 py-1 rounded",
@@ -261,13 +225,63 @@ export function TaskDetailsSidebar({
             </div>
           </div>
 
+          {/* Project */}
+          <div>
+            <span className="text-sm text-muted-foreground">Project</span>
+            <div className="mt-1">
+              <Select
+                value={task.project || "none"}
+                onValueChange={useCallback((value: string) => {
+                  const projectId = value === "none" ? undefined : value;
+                  const areaId = getAreaFromProject(projectId);
+                  onUpdateTask({
+                    project: projectId,
+                    area: areaId
+                  });
+                }, [onUpdateTask, getAreaFromProject])}
+              >
+                <SelectTrigger className="w-auto h-auto p-0 border-none bg-transparent hover:bg-transparent focus:ring-0 focus:ring-offset-0 [&>svg]:hidden">
+                  <span className="text-sm font-medium text-foreground">
+                    {task.project ? projects.find(p => p.id === task.project)?.title || 'Unknown Project' : 'No project'}
+                  </span>
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="none">No project</SelectItem>
+                  {projects.map((project) => (
+                    <SelectItem key={project.id} value={project.id}>
+                      {project.title}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          {/* Due Date */}
+          <div>
+            <span className="text-sm text-muted-foreground">Due Date</span>
+            <div className="mt-1">
+              <TaskDateTimePicker
+                date={task.dueDate}
+                onDateChange={useCallback((date: Date | undefined) =>
+                  onUpdateTask({ dueDate: date }), [onUpdateTask])}
+                placeholder="Pick a date"
+                align="start"
+                side="left"
+                allowClear={true}
+              />
+            </div>
+          </div>
+
           {/* Completed Date (if task is completed) */}
           {task.completed !== null && (
-            <div className="flex items-center justify-between">
-              <span className="text-sm font-medium text-foreground">Completed</span>
-              <span className="text-sm text-muted-foreground">
-                {formatDateTime(task.completed)}
-              </span>
+            <div>
+              <span className="text-sm text-muted-foreground">Completed</span>
+              <div className="mt-1">
+                <span className="text-sm font-medium text-foreground">
+                  {formatDateTime(task.completed)}
+                </span>
+              </div>
             </div>
           )}
         </div>

--- a/src/components/TaskDetailsSidebar.tsx
+++ b/src/components/TaskDetailsSidebar.tsx
@@ -120,16 +120,45 @@ export function TaskDetailsSidebar({
           <div className="flex items-center gap-2">
             <Select
               value={task.priority}
-              onValueChange={useCallback((value: string) => 
+              onValueChange={useCallback((value: string) =>
                 onUpdateTask({ priority: value as Task["priority"] }), [onUpdateTask])}
             >
-              <SelectTrigger className="w-24 h-7">
-                <SelectValue />
+              <SelectTrigger className="w-auto h-auto p-0 border-none bg-transparent hover:bg-transparent focus:ring-0 focus:ring-offset-0">
+                <img
+                  src="https://cdn.builder.io/api/v1/image/assets%2F871cdad99f0e4f7383e2724856d9c17b%2F63cf4952854846e5994e15d4c2b9fc7e?format=webp&width=800"
+                  alt="Priority flag"
+                  className={cn("w-6 h-6",
+                    task.priority === "low" && "brightness-0 sepia-1 hue-rotate-210 saturate-3",
+                    task.priority === "medium" && "brightness-0 sepia-1 hue-rotate-60 saturate-5",
+                    task.priority === "urgent" && "brightness-0 sepia-1 hue-rotate-0 saturate-7"
+                  )}
+                />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="low">Low</SelectItem>
-                <SelectItem value="medium">Medium</SelectItem>
-                <SelectItem value="urgent">Urgent</SelectItem>
+                <SelectItem value="low" className="flex items-center gap-2">
+                  <img
+                    src="https://cdn.builder.io/api/v1/image/assets%2F871cdad99f0e4f7383e2724856d9c17b%2F63cf4952854846e5994e15d4c2b9fc7e?format=webp&width=800"
+                    alt="Low priority"
+                    className="w-4 h-4 brightness-0 sepia-1 hue-rotate-210 saturate-3"
+                  />
+                  Low
+                </SelectItem>
+                <SelectItem value="medium" className="flex items-center gap-2">
+                  <img
+                    src="https://cdn.builder.io/api/v1/image/assets%2F871cdad99f0e4f7383e2724856d9c17b%2F63cf4952854846e5994e15d4c2b9fc7e?format=webp&width=800"
+                    alt="Medium priority"
+                    className="w-4 h-4 brightness-0 sepia-1 hue-rotate-60 saturate-5"
+                  />
+                  Medium
+                </SelectItem>
+                <SelectItem value="urgent" className="flex items-center gap-2">
+                  <img
+                    src="https://cdn.builder.io/api/v1/image/assets%2F871cdad99f0e4f7383e2724856d9c17b%2F63cf4952854846e5994e15d4c2b9fc7e?format=webp&width=800"
+                    alt="High priority"
+                    className="w-4 h-4 brightness-0 sepia-1 hue-rotate-0 saturate-7"
+                  />
+                  High
+                </SelectItem>
               </SelectContent>
             </Select>
           </div>

--- a/src/components/TaskDetailsSidebar.tsx
+++ b/src/components/TaskDetailsSidebar.tsx
@@ -124,40 +124,50 @@ export function TaskDetailsSidebar({
                 onUpdateTask({ priority: value as Task["priority"] }), [onUpdateTask])}
             >
               <SelectTrigger className="w-auto h-auto p-0 border-none bg-transparent hover:bg-transparent focus:ring-0 focus:ring-offset-0">
-                <img
-                  src="https://cdn.builder.io/api/v1/image/assets%2F871cdad99f0e4f7383e2724856d9c17b%2F63cf4952854846e5994e15d4c2b9fc7e?format=webp&width=800"
-                  alt="Priority flag"
-                  className={cn("w-6 h-6",
-                    task.priority === "low" && "brightness-0 sepia-1 hue-rotate-210 saturate-3",
-                    task.priority === "medium" && "brightness-0 sepia-1 hue-rotate-60 saturate-5",
-                    task.priority === "urgent" && "brightness-0 sepia-1 hue-rotate-0 saturate-7"
-                  )}
-                />
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path
+                    d="M6 4L18 4C18.5523 4 19 4.44772 19 5V19C19 19.5523 18.5523 20 18 20H6C5.44772 20 5 19.5523 5 19V5C5 4.44772 5.44772 4 6 4Z"
+                    fill={
+                      task.priority === "urgent" ? "#ef4444" :
+                      task.priority === "medium" ? "#eab308" :
+                      "#3b82f6"
+                    }
+                  />
+                </svg>
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="low" className="flex items-center gap-2">
-                  <img
-                    src="https://cdn.builder.io/api/v1/image/assets%2F871cdad99f0e4f7383e2724856d9c17b%2F63cf4952854846e5994e15d4c2b9fc7e?format=webp&width=800"
-                    alt="Low priority"
-                    className="w-4 h-4 brightness-0 sepia-1 hue-rotate-210 saturate-3"
-                  />
-                  Low
+                <SelectItem value="low">
+                  <div className="flex items-center gap-2">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <path
+                        d="M6 4L18 4C18.5523 4 19 4.44772 19 5V19C19 19.5523 18.5523 20 18 20H6C5.44772 20 5 19.5523 5 19V5C5 4.44772 5.44772 4 6 4Z"
+                        fill="#3b82f6"
+                      />
+                    </svg>
+                    <span>Low</span>
+                  </div>
                 </SelectItem>
-                <SelectItem value="medium" className="flex items-center gap-2">
-                  <img
-                    src="https://cdn.builder.io/api/v1/image/assets%2F871cdad99f0e4f7383e2724856d9c17b%2F63cf4952854846e5994e15d4c2b9fc7e?format=webp&width=800"
-                    alt="Medium priority"
-                    className="w-4 h-4 brightness-0 sepia-1 hue-rotate-60 saturate-5"
-                  />
-                  Medium
+                <SelectItem value="medium">
+                  <div className="flex items-center gap-2">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <path
+                        d="M6 4L18 4C18.5523 4 19 4.44772 19 5V19C19 19.5523 18.5523 20 18 20H6C5.44772 20 5 19.5523 5 19V5C5 4.44772 5.44772 4 6 4Z"
+                        fill="#eab308"
+                      />
+                    </svg>
+                    <span>Medium</span>
+                  </div>
                 </SelectItem>
-                <SelectItem value="urgent" className="flex items-center gap-2">
-                  <img
-                    src="https://cdn.builder.io/api/v1/image/assets%2F871cdad99f0e4f7383e2724856d9c17b%2F63cf4952854846e5994e15d4c2b9fc7e?format=webp&width=800"
-                    alt="High priority"
-                    className="w-4 h-4 brightness-0 sepia-1 hue-rotate-0 saturate-7"
-                  />
-                  High
+                <SelectItem value="urgent">
+                  <div className="flex items-center gap-2">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <path
+                        d="M6 4L18 4C18.5523 4 19 4.44772 19 5V19C19 19.5523 18.5523 20 18 20H6C5.44772 20 5 19.5523 5 19V5C5 4.44772 5.44772 4 6 4Z"
+                        fill="#ef4444"
+                      />
+                    </svg>
+                    <span>High</span>
+                  </div>
                 </SelectItem>
               </SelectContent>
             </Select>

--- a/src/components/TaskDetailsSidebar.tsx
+++ b/src/components/TaskDetailsSidebar.tsx
@@ -111,9 +111,9 @@ export function TaskDetailsSidebar({
       </div>
 
       {/* Content */}
-      <div className="flex-1 overflow-y-auto p-4 space-y-4">
+      <div className="flex-1 overflow-y-auto p-4 flex flex-col">
         {/* Title and checkbox row */}
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-3 mb-4">
           <input
             type="checkbox"
             checked={task.completed !== null}
@@ -132,7 +132,7 @@ export function TaskDetailsSidebar({
         </div>
 
         {/* Properties with horizontal layout */}
-        <div className="space-y-3">
+        <div className="space-y-3 mb-4">
           {/* Timeframe */}
           <div className="flex items-center">
             <span className="text-sm text-muted-foreground w-20">Timeframe</span>
@@ -142,7 +142,7 @@ export function TaskDetailsSidebar({
                 onUpdateTask({ timeframe: value as Task["timeframe"] }), [onUpdateTask])}
             >
               <SelectTrigger className="w-auto h-auto p-0 border-none bg-transparent hover:bg-transparent focus:ring-0 focus:ring-offset-0 [&>svg]:hidden">
-                <span className="text-sm font-medium text-foreground">
+                <span className={cn("text-xs px-2 py-1 rounded font-medium uppercase", getTimeframeColor(task.timeframe))}>
                   {task.timeframe}
                 </span>
               </SelectTrigger>
@@ -271,15 +271,9 @@ export function TaskDetailsSidebar({
           {/* Due Date */}
           <div className="flex items-center">
             <span className="text-sm text-muted-foreground w-20">Due Date</span>
-            <TaskDateTimePicker
-              date={task.dueDate}
-              onDateChange={useCallback((date: Date | undefined) =>
-                onUpdateTask({ dueDate: date }), [onUpdateTask])}
-              placeholder="Pick a date"
-              align="start"
-              side="left"
-              allowClear={true}
-            />
+            <span className="text-sm font-medium text-foreground">
+              {task.dueDate ? formatDateTime(task.dueDate) : 'No due date'}
+            </span>
           </div>
 
           {/* Completed Date (if task is completed) */}
@@ -294,22 +288,54 @@ export function TaskDetailsSidebar({
         </div>
 
         {/* Divider */}
-        <div className="border-t border-border my-4"></div>
+        <div className="border-t border-border mb-4"></div>
 
-        {/* Description */}
-        <div>
-          <h4 className="text-sm font-medium text-foreground mb-2">Description</h4>
-          <Textarea
-            value={task.description || ""}
-            onChange={useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) =>
-              onUpdateTask({ description: e.target.value }), [onUpdateTask])}
-            placeholder="Enter task description"
-            rows={3}
-          />
+        {/* Tabs */}
+        <div className="flex border-b border-border mb-4">
+          <button
+            onClick={() => setActiveTab("description")}
+            className={cn(
+              "px-4 py-2 text-sm font-medium border-b-2 transition-colors",
+              activeTab === "description"
+                ? "border-primary text-primary"
+                : "border-transparent text-muted-foreground hover:text-foreground"
+            )}
+          >
+            Description
+          </button>
+          <button
+            onClick={() => setActiveTab("activity")}
+            className={cn(
+              "px-4 py-2 text-sm font-medium border-b-2 transition-colors",
+              activeTab === "activity"
+                ? "border-primary text-primary"
+                : "border-transparent text-muted-foreground hover:text-foreground"
+            )}
+          >
+            Activity
+          </button>
         </div>
 
-        {/* Bottom row: Created and Task ID */}
-        <div className="flex items-center justify-between pt-4 mt-auto">
+        {/* Tab Content */}
+        <div className="flex-1 mb-4">
+          {activeTab === "description" ? (
+            <Textarea
+              value={task.description || ""}
+              onChange={useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                onUpdateTask({ description: e.target.value }), [onUpdateTask])}
+              placeholder="Enter task description"
+              rows={3}
+              className="min-h-[100px]"
+            />
+          ) : (
+            <div className="text-sm text-muted-foreground">
+              Activity feed coming soon...
+            </div>
+          )}
+        </div>
+
+        {/* Bottom row: Created and Task ID - Fixed at bottom */}
+        <div className="flex items-center justify-between pt-4 mt-auto border-t border-border">
           <div className="flex flex-col">
             <span className="text-xs font-medium text-foreground">Created</span>
             <span className="text-xs text-muted-foreground">

--- a/src/components/TaskDetailsSidebar.tsx
+++ b/src/components/TaskDetailsSidebar.tsx
@@ -86,11 +86,11 @@ export function TaskDetailsSidebar({
   areas,
   getAreaFromProject
 }: TaskDetailsSidebarProps) {
-  const [activeTab, setActiveTab] = useState<"description" | "activity">("description");
-
   if (!isOpen || !task) {
     return null;
   }
+
+  const [activeTab, setActiveTab] = useState<"description" | "activity">("description");
 
   return (
     <div className="fixed right-0 top-0 h-full w-96 bg-white border-l border-border z-50 overflow-hidden flex flex-col">

--- a/src/components/TaskDetailsSidebar.tsx
+++ b/src/components/TaskDetailsSidebar.tsx
@@ -347,6 +347,21 @@ export function TaskDetailsSidebar({
           )}
         </div>
 
+        {/* Bottom row: Created and Task ID - Fixed at bottom */}
+        <div className="flex items-center justify-between pt-4 mt-auto">
+          <div className="flex flex-col">
+            <span className="text-xs font-medium text-foreground">Created</span>
+            <span className="text-xs text-muted-foreground">
+              {formatDateTime(task.created)}
+            </span>
+          </div>
+          <div className="flex flex-col items-end">
+            <span className="text-xs font-medium text-foreground">Task ID</span>
+            <code className="text-xs bg-muted text-muted-foreground px-2 py-1 rounded font-mono">
+              {task.id}
+            </code>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/components/TaskDetailsSidebar.tsx
+++ b/src/components/TaskDetailsSidebar.tsx
@@ -335,8 +335,7 @@ export function TaskDetailsSidebar({
           {activeTab === "description" ? (
             <Textarea
               value={task.description || ""}
-              onChange={useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) =>
-                onUpdateTask({ description: e.target.value }), [onUpdateTask])}
+              onChange={handleDescriptionChange}
               placeholder="Enter task description"
               rows={3}
               className="min-h-[100px]"

--- a/src/components/TaskDetailsSidebar.tsx
+++ b/src/components/TaskDetailsSidebar.tsx
@@ -150,7 +150,7 @@ export function TaskDetailsSidebar({
           <Input
             value={task.title}
             onChange={handleTitleChange}
-            className="text-lg font-semibold border-none p-0 h-auto focus-visible:ring-0 bg-transparent flex-1"
+            className="text-lg leading-[22px] font-semibold border-none p-0 h-auto focus-visible:ring-0 bg-transparent flex-1"
           />
         </div>
 

--- a/src/components/TaskManagement.tsx
+++ b/src/components/TaskManagement.tsx
@@ -989,11 +989,10 @@ export function TaskManagement({ onTaskSidebarChange }: TaskManagementProps = {}
                                 </span>}
                               <span className={cn("text-xs px-2 py-1 rounded font-medium uppercase", getTimeframeColor(task.timeframe))}>
                                 {task.timeframe}
-                              </span>
-                            </div>
+                            </span>
                           </div>
-                          {task.description && <p className="text-sm text-muted-foreground mt-1">{task.description}</p>}
                         </div>
+                      </div>
                       </div>
                     </div>)}
                 </div>}

--- a/src/components/TaskManagement.tsx
+++ b/src/components/TaskManagement.tsx
@@ -1207,11 +1207,10 @@ export function TaskManagement({ onTaskSidebarChange }: TaskManagementProps = {}
                                  onDateChange={updateTaskDueDate}
                                  formatFunction={formatTodayViewDate}
                                  className={cn("text-xs text-muted-foreground font-medium", isTaskOverdue(task) && "text-red-500")}
-                               />}
-                             </div>
+                             />}
                            </div>
-                           {task.description && <p className="text-sm text-muted-foreground mt-1">{task.description}</p>}
                          </div>
+                       </div>
                        </div>
                      </div>)}
                 </div>}

--- a/src/components/TaskManagement.tsx
+++ b/src/components/TaskManagement.tsx
@@ -1153,7 +1153,6 @@ export function TaskManagement({ onTaskSidebarChange }: TaskManagementProps = {}
                   </span>
                 </div>
               </div>
-              {task.description && <p className="text-sm text-muted-foreground mt-1">{task.description}</p>}
             </div>
           </div>
         </div>)}

--- a/src/components/TaskManagement.tsx
+++ b/src/components/TaskManagement.tsx
@@ -1095,7 +1095,6 @@ export function TaskManagement({ onTaskSidebarChange }: TaskManagementProps = {}
                   </InlineTaskDateTimePicker>
                 </div>
               </div>
-              {task.description && <p className="text-sm text-muted-foreground mt-1">{task.description}</p>}
             </div>
           </div>
         </div>)}


### PR DESCRIPTION
## Purpose

The user wanted to clean up the task management interface by:
- Removing task descriptions from all card views (kanban, list, today view) to reduce visual clutter
- Keeping descriptions visible only in the detailed task sidebar view
- Improving the task details sidebar layout and user experience

## Code changes

**Task card views:**
- Removed description display from kanban board task cards
- Removed description display from list view task items  
- Removed description display from today view task cards
- Fixed HTML structure issues with extra closing divs

**Task details sidebar:**
- Complete redesign with improved layout and user experience
- Added tabbed interface with "Description" and "Activity" tabs
- Reorganized properties into horizontal layout with consistent spacing
- Enhanced visual design for timeframe, priority, and project selectors
- Added proper state management with useState for active tab
- Moved task title and checkbox to top of sidebar
- Added proper textarea for description editing
- Fixed positioning of created date and task ID at bottom
- Improved responsive design and visual hierarchy

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 19`

🔗 [Edit in Builder.io](https://builder.io/app/projects/b0be7e3daec147bb8e053736d39a066c/curry-sanctuary)

👀 [Preview Link](https://b0be7e3daec147bb8e053736d39a066c-curry-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b0be7e3daec147bb8e053736d39a066c</projectId>-->
<!--<branchName>curry-sanctuary</branchName>-->