### PR TITLE
Add task creation buttons to kanban columns with misc project

### DIFF
--- a/src/components/GoalManagement.tsx
+++ b/src/components/GoalManagement.tsx
@@ -417,15 +417,29 @@ export function GoalManagement({
         <div className="mt-8 bg-white rounded-lg border border-gray-200 p-6">
           <div className="flex items-center justify-between mb-6">
             <div className="flex items-center gap-3">
-              <div className={cn("w-4 h-4 rounded-full", getStatusCircleColor(editingGoal.status))} />
               <h2 className="text-2xl font-bold text-foreground">{editingGoal.title}</h2>
               <Badge className={cn("text-xs px-2 py-1", getStatusColor(editingGoal.status))}>
                 {getStatusLabel(editingGoal.status)}
               </Badge>
             </div>
-            <Button variant="outline" size="sm" onClick={() => setSelectedGoal(null)}>
-              Close
-            </Button>
+            <div className="flex items-center gap-4">
+              {(() => {
+                const area = areas.find(a => a.id === editingGoal.area);
+                return area ? (
+                  <Badge className={cn("text-xs text-white px-2 py-1", area.color)}>
+                    {area.name}
+                  </Badge>
+                ) : null;
+              })()}
+              {formatDateRange(editingGoal.startDate, editingGoal.endDate) && (
+                <span className="text-sm text-muted-foreground">
+                  {formatDateRange(editingGoal.startDate, editingGoal.endDate)}
+                </span>
+              )}
+              <Button variant="outline" size="sm" onClick={() => setSelectedGoal(null)}>
+                Close
+              </Button>
+            </div>
           </div>
 
           {editingGoal.description && (

--- a/src/components/GoalManagement.tsx
+++ b/src/components/GoalManagement.tsx
@@ -491,27 +491,73 @@ export function GoalManagement({
 
               return (
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                  {attachedProjects.map(project => (
-                    <div key={project.id} className="bg-gray-50 rounded-lg p-4 border">
-                      <div className="flex items-center gap-2 mb-2">
-                        <div className={cn(
-                          "w-3 h-3 rounded-full",
-                          project.status === "finished" ? "bg-green-500" :
-                          project.status === "active" ? "bg-blue-500" :
-                          project.status === "lead" ? "bg-yellow-500" : "bg-gray-500"
-                        )} />
-                        <h4 className="font-medium text-sm">{project.title}</h4>
-                      </div>
-                      <div className="text-xs text-muted-foreground mb-2">
-                        Status: <span className="capitalize">{project.status}</span>
-                      </div>
-                      {project.steps && (
-                        <div className="text-xs text-muted-foreground">
-                          Steps: {project.steps.filter(s => s.completed).length} / {project.steps.length} completed
+                  {attachedProjects.map(project => {
+                    const area = areas.find(a => a.id === project.area);
+                    const formatEndDate = (startDate?: Date, endDate?: Date) => {
+                      if (endDate) {
+                        return format(endDate, "MMM d, yyyy");
+                      }
+                      if (startDate) {
+                        return `Starts ${format(startDate, "MMM d, yyyy")}`;
+                      }
+                      return "No end date";
+                    };
+
+                    return (
+                      <div
+                        key={project.id}
+                        className="bg-card border border-border rounded-lg p-4 shadow-soft hover:shadow-medium transition-all duration-200 cursor-pointer"
+                      >
+                        <div className="space-y-3">
+                          <div className="flex items-start justify-between gap-2">
+                            <div className="flex items-center gap-2 flex-1">
+                              <div className={cn(
+                                "w-3 h-3 rounded-full shrink-0",
+                                project.status === "finished" ? "bg-green-500" :
+                                project.status === "active" ? "bg-orange-500" :
+                                project.status === "lead" ? "bg-red-500" : "bg-gray-600"
+                              )} />
+                              <h3 className="font-semibold text-card-foreground text-base line-clamp-2 flex-1">{project.title}</h3>
+                            </div>
+                          </div>
+
+                          <div className="space-y-2 text-xs">
+                            <div className="text-muted-foreground truncate">
+                              {formatEndDate(project.startDate, project.endDate)}
+                            </div>
+                            <div className="flex items-center gap-1">
+                            </div>
+                          </div>
+
+                          {/* Progress bar and area tag row */}
+                          <div className="flex items-center justify-between gap-2">
+                            {/* Progress bar on the left */}
+                            <div className="flex items-center gap-2">
+                              <div className="w-16 h-1.5 bg-muted rounded-full overflow-hidden">
+                                <div
+                                  className="h-full bg-primary rounded-full"
+                                  style={{
+                                    width: `${project.steps.length > 0 ? (project.steps.filter(s => s.completed).length / project.steps.length) * 100 : 0}%`,
+                                    transition: 'width 0.3s ease-out'
+                                  }}
+                                />
+                              </div>
+                              <span className="text-xs text-muted-foreground whitespace-nowrap">
+                                {project.steps.filter(s => s.completed).length} / {project.steps.length}
+                              </span>
+                            </div>
+
+                            {/* Area tag on the right */}
+                            {area && (
+                              <span className={cn("text-xs text-white px-2 py-1 rounded", area.color)}>
+                                {area.name}
+                              </span>
+                            )}
+                          </div>
                         </div>
-                      )}
-                    </div>
-                  ))}
+                      </div>
+                    );
+                  })}
                 </div>
               );
             })()}

--- a/src/components/GoalManagement.tsx
+++ b/src/components/GoalManagement.tsx
@@ -243,6 +243,7 @@ export function GoalManagement({
   const [editingGoal, setEditingGoal] = useState<Goal | null>(null);
   const [isEditing, setIsEditing] = useState(false);
   const [sortBy, setSortBy] = useState<"status" | "date" | "area" | "none">("none");
+  const [dragOverColumn, setDragOverColumn] = useState<string | null>(null);
   
   const [newGoal, setNewGoal] = useState({
     title: "",

--- a/src/components/GoalManagement.tsx
+++ b/src/components/GoalManagement.tsx
@@ -476,7 +476,7 @@ export function GoalManagement({
 
           {/* Attached Projects */}
           <div>
-            <h3 className="text-lg font-semibold mb-4">Attached Projects</h3>
+            <h3 className="text-lg font-semibold mb-4">Projects</h3>
             {(() => {
               const attachedProjects = availableProjects.filter(p => editingGoal.projectIds.includes(p.id));
 

--- a/src/components/GoalManagement.tsx
+++ b/src/components/GoalManagement.tsx
@@ -540,21 +540,19 @@ export function GoalManagement({
               return (
                 <div className="flex gap-4 overflow-x-auto">
                   {statuses.map(status => {
-                    const [isDragOver, setIsDragOver] = useState(false);
-
                     const handleDragOver = (e: React.DragEvent) => {
                       e.preventDefault();
-                      setIsDragOver(true);
+                      setDragOverColumn(status);
                     };
 
                     const handleDragLeave = (e: React.DragEvent) => {
                       e.preventDefault();
-                      setIsDragOver(false);
+                      setDragOverColumn(null);
                     };
 
                     const handleDrop = (e: React.DragEvent) => {
                       e.preventDefault();
-                      setIsDragOver(false);
+                      setDragOverColumn(null);
                       const projectId = e.dataTransfer.getData("text/plain");
                       updateProjectStatus(projectId, status);
                     };
@@ -565,7 +563,7 @@ export function GoalManagement({
                         className={cn(
                           "flex-1 min-w-64 bg-[#f3f3f3] rounded-lg transition-colors",
                           getColumnColor(status),
-                          isDragOver && "bg-muted/50"
+                          dragOverColumn === status && "bg-muted/50"
                         )}
                         onDragOver={handleDragOver}
                         onDragLeave={handleDragLeave}

--- a/src/components/GoalManagement.tsx
+++ b/src/components/GoalManagement.tsx
@@ -449,73 +449,23 @@ export function GoalManagement({
             </div>
           )}
 
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
-            {/* Goal Details */}
-            <div>
-              <h3 className="text-lg font-semibold mb-4">Goal Details</h3>
-              <div className="space-y-3">
+          <div className="mb-6">
+            {(() => {
+              const progress = getGoalProgress(editingGoal);
+              return (
                 <div>
-                  <Label className="text-sm font-medium">Area</Label>
-                  <div className="mt-1">
-                    {(() => {
-                      const area = areas.find(a => a.id === editingGoal.area);
-                      return area ? (
-                        <Badge className={cn("text-xs text-white px-2 py-1", area.color)}>
-                          {area.name}
-                        </Badge>
-                      ) : (
-                        <span className="text-sm text-muted-foreground">No area assigned</span>
-                      );
-                    })()}
+                  <div className="flex items-center justify-between text-sm mb-2">
+                    <span className="font-medium">{progress.completed} / {progress.total}</span>
+                  </div>
+                  <div className="w-full bg-gray-200 rounded-full h-3">
+                    <div
+                      className="bg-primary h-3 rounded-full transition-all duration-300"
+                      style={{ width: `${progress.percentage}%` }}
+                    />
                   </div>
                 </div>
-
-                <div>
-                  <Label className="text-sm font-medium">Timeline</Label>
-                  <div className="mt-1 text-sm text-muted-foreground">
-                    {formatDateRange(editingGoal.startDate, editingGoal.endDate) || "No timeline set"}
-                  </div>
-                </div>
-
-                <div>
-                  <Label className="text-sm font-medium">Status</Label>
-                  <div className="mt-1">
-                    <Badge className={cn("text-xs px-2 py-1", getStatusColor(editingGoal.status))}>
-                      {getStatusLabel(editingGoal.status)}
-                    </Badge>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            {/* Progress Overview */}
-            <div>
-              <h3 className="text-lg font-semibold mb-4">Progress Overview</h3>
-              <div className="space-y-4">
-                {(() => {
-                  const progress = getGoalProgress(editingGoal);
-                  return (
-                    <>
-                      <div>
-                        <div className="flex items-center justify-between text-sm mb-2">
-                          <span className="font-medium">Overall Progress</span>
-                          <span className="font-medium">{progress.completed} / {progress.total} projects</span>
-                        </div>
-                        <div className="w-full bg-gray-200 rounded-full h-3">
-                          <div
-                            className="bg-primary h-3 rounded-full transition-all duration-300"
-                            style={{ width: `${progress.percentage}%` }}
-                          />
-                        </div>
-                        <div className="text-xs text-muted-foreground mt-1">
-                          {Math.round(progress.percentage)}% complete
-                        </div>
-                      </div>
-                    </>
-                  );
-                })()}
-              </div>
-            </div>
+              );
+            })()}
           </div>
 
           {/* Attached Projects */}

--- a/src/components/GoalManagement.tsx
+++ b/src/components/GoalManagement.tsx
@@ -489,75 +489,120 @@ export function GoalManagement({
                 );
               }
 
+              // Group projects by status
+              const statuses = ["lead", "active", "finished", "archive"] as const;
+              const projectsByStatus = statuses.reduce((acc, status) => {
+                acc[status] = attachedProjects.filter(p => p.status === status);
+                return acc;
+              }, {} as Record<string, typeof attachedProjects>);
+
+              const getStatusLabel = (status: string) => {
+                switch (status) {
+                  case "lead": return "Lead";
+                  case "active": return "Active";
+                  case "finished": return "Finished";
+                  case "archive": return "Archive";
+                  default: return status;
+                }
+              };
+
+              const getColumnColor = (status: string) => {
+                switch (status) {
+                  case "lead": return "border-t-red-500";
+                  case "active": return "border-t-orange-500";
+                  case "finished": return "border-t-green-500";
+                  case "archive": return "border-t-gray-500";
+                  default: return "border-t-border";
+                }
+              };
+
+              const formatEndDate = (startDate?: Date, endDate?: Date) => {
+                if (endDate) {
+                  return format(endDate, "MMM d, yyyy");
+                }
+                if (startDate) {
+                  return `Starts ${format(startDate, "MMM d, yyyy")}`;
+                }
+                return "No end date";
+              };
+
               return (
-                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                  {attachedProjects.map(project => {
-                    const area = areas.find(a => a.id === project.area);
-                    const formatEndDate = (startDate?: Date, endDate?: Date) => {
-                      if (endDate) {
-                        return format(endDate, "MMM d, yyyy");
-                      }
-                      if (startDate) {
-                        return `Starts ${format(startDate, "MMM d, yyyy")}`;
-                      }
-                      return "No end date";
-                    };
+                <div className="flex gap-4 overflow-x-auto">
+                  {statuses.map(status => (
+                    <div
+                      key={status}
+                      className={cn("flex-1 min-w-64 bg-[#f3f3f3] rounded-lg", getColumnColor(status))}
+                    >
+                      <div className="p-4">
+                        <div className="flex items-center justify-between mb-4">
+                          <h4 className="text-lg font-semibold text-foreground">{getStatusLabel(status)}</h4>
+                          <span className="text-sm text-muted-foreground bg-background px-2 py-1 rounded">
+                            {projectsByStatus[status].length}
+                          </span>
+                        </div>
+                        <div className="space-y-2">
+                          {projectsByStatus[status].map(project => {
+                            const area = areas.find(a => a.id === project.area);
 
-                    return (
-                      <div
-                        key={project.id}
-                        className="bg-card border border-border rounded-lg p-4 shadow-soft hover:shadow-medium transition-all duration-200 cursor-pointer"
-                      >
-                        <div className="space-y-3">
-                          <div className="flex items-start justify-between gap-2">
-                            <div className="flex items-center gap-2 flex-1">
-                              <div className={cn(
-                                "w-3 h-3 rounded-full shrink-0",
-                                project.status === "finished" ? "bg-green-500" :
-                                project.status === "active" ? "bg-orange-500" :
-                                project.status === "lead" ? "bg-red-500" : "bg-gray-600"
-                              )} />
-                              <h3 className="font-semibold text-card-foreground text-base line-clamp-2 flex-1">{project.title}</h3>
-                            </div>
-                          </div>
+                            return (
+                              <div
+                                key={project.id}
+                                className="bg-card border border-border rounded-lg p-4 shadow-soft hover:shadow-medium transition-all duration-200 cursor-pointer"
+                              >
+                                <div className="space-y-3">
+                                  <div className="flex items-start justify-between gap-2">
+                                    <div className="flex items-center gap-2 flex-1">
+                                      <div className={cn(
+                                        "w-3 h-3 rounded-full shrink-0",
+                                        project.status === "finished" ? "bg-green-500" :
+                                        project.status === "active" ? "bg-orange-500" :
+                                        project.status === "lead" ? "bg-red-500" : "bg-gray-600"
+                                      )} />
+                                      <h3 className="font-semibold text-card-foreground text-base line-clamp-2 flex-1">{project.title}</h3>
+                                    </div>
+                                  </div>
 
-                          <div className="space-y-2 text-xs">
-                            <div className="text-muted-foreground truncate">
-                              {formatEndDate(project.startDate, project.endDate)}
-                            </div>
-                            <div className="flex items-center gap-1">
-                            </div>
-                          </div>
+                                  <div className="space-y-2 text-xs">
+                                    <div className="text-muted-foreground truncate">
+                                      {formatEndDate(project.startDate, project.endDate)}
+                                    </div>
+                                    <div className="flex items-center gap-1">
+                                    </div>
+                                  </div>
 
-                          {/* Progress bar and area tag row */}
-                          <div className="flex items-center justify-between gap-2">
-                            {/* Progress bar on the left */}
-                            <div className="flex items-center gap-2">
-                              <div className="w-16 h-1.5 bg-muted rounded-full overflow-hidden">
-                                <div
-                                  className="h-full bg-primary rounded-full"
-                                  style={{
-                                    width: `${project.steps.length > 0 ? (project.steps.filter(s => s.completed).length / project.steps.length) * 100 : 0}%`,
-                                    transition: 'width 0.3s ease-out'
-                                  }}
-                                />
+                                  {/* Progress bar and area tag row */}
+                                  <div className="flex items-center justify-between gap-2">
+                                    {/* Progress bar on the left */}
+                                    <div className="flex items-center gap-2">
+                                      <div className="w-16 h-1.5 bg-muted rounded-full overflow-hidden">
+                                        <div
+                                          className="h-full bg-primary rounded-full"
+                                          style={{
+                                            width: `${project.steps.length > 0 ? (project.steps.filter(s => s.completed).length / project.steps.length) * 100 : 0}%`,
+                                            transition: 'width 0.3s ease-out'
+                                          }}
+                                        />
+                                      </div>
+                                      <span className="text-xs text-muted-foreground whitespace-nowrap">
+                                        {project.steps.filter(s => s.completed).length} / {project.steps.length}
+                                      </span>
+                                    </div>
+
+                                    {/* Area tag on the right */}
+                                    {area && (
+                                      <span className={cn("text-xs text-white px-2 py-1 rounded", area.color)}>
+                                        {area.name}
+                                      </span>
+                                    )}
+                                  </div>
+                                </div>
                               </div>
-                              <span className="text-xs text-muted-foreground whitespace-nowrap">
-                                {project.steps.filter(s => s.completed).length} / {project.steps.length}
-                              </span>
-                            </div>
-
-                            {/* Area tag on the right */}
-                            {area && (
-                              <span className={cn("text-xs text-white px-2 py-1 rounded", area.color)}>
-                                {area.name}
-                              </span>
-                            )}
-                          </div>
+                            );
+                          })}
                         </div>
                       </div>
-                    );
-                  })}
+                    </div>
+                  ))}
                 </div>
               );
             })()}

--- a/src/components/GoalManagement.tsx
+++ b/src/components/GoalManagement.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback } from "react";
-import { Calendar, Plus, MoreHorizontal, Filter, ArrowUpDown, Target, Folder } from "lucide-react";
+import { Calendar, Plus, MoreHorizontal, Filter, ArrowUpDown, Target, Folder, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";

--- a/src/components/GoalManagement.tsx
+++ b/src/components/GoalManagement.tsx
@@ -442,30 +442,36 @@ export function GoalManagement({
             </div>
           </div>
 
-          {editingGoal.description && (
-            <div className="mb-6">
-              <h3 className="text-lg font-semibold mb-2">Description</h3>
-              <p className="text-muted-foreground">{editingGoal.description}</p>
-            </div>
-          )}
-
-          <div className="mb-6">
+          <div className="flex items-center gap-3 mb-6">
             {(() => {
               const progress = getGoalProgress(editingGoal);
               return (
-                <div>
-                  <div className="flex items-center justify-between text-sm mb-2">
-                    <span className="font-medium">{progress.completed} / {progress.total}</span>
-                  </div>
-                  <div className="w-full bg-gray-200 rounded-full h-3">
+                <>
+                  <div className="w-32 h-2 bg-muted rounded-full overflow-hidden">
                     <div
-                      className="bg-primary h-3 rounded-full transition-all duration-300"
-                      style={{ width: `${progress.percentage}%` }}
+                      className="h-full bg-primary rounded-full"
+                      style={{
+                        width: `${progress.percentage}%`,
+                        transition: 'width 0.3s ease-out'
+                      }}
                     />
                   </div>
-                </div>
+                  <span className="text-sm text-muted-foreground whitespace-nowrap">
+                    {progress.completed} / {progress.total}
+                  </span>
+                </>
               );
             })()}
+          </div>
+
+          <div>
+            <Textarea
+              value={editingGoal.description || ""}
+              onChange={(e) => updateEditingGoal({ description: e.target.value })}
+              className="border-none bg-transparent p-0 resize-none focus-visible:ring-0"
+              placeholder="Enter goal description..."
+              rows={3}
+            />
           </div>
 
           {/* Attached Projects */}

--- a/src/components/GoalManagement.tsx
+++ b/src/components/GoalManagement.tsx
@@ -437,7 +437,7 @@ export function GoalManagement({
                 </span>
               )}
               <Button variant="outline" size="sm" onClick={() => setSelectedGoal(null)}>
-                Close
+                <X className="h-4 w-4" />
               </Button>
             </div>
           </div>

--- a/src/components/KanbanBoard.tsx
+++ b/src/components/KanbanBoard.tsx
@@ -352,6 +352,20 @@ const KanbanColumn = ({
             />
           ))}
         </div>
+
+        {/* Add task button */}
+        {onAddTask && (
+          <div className="mt-4">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => onAddTask(timeframe)}
+              className="text-sm text-muted-foreground hover:text-foreground p-0 h-auto font-normal w-full justify-start"
+            >
+              + add task
+            </Button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/KanbanBoard.tsx
+++ b/src/components/KanbanBoard.tsx
@@ -382,6 +382,7 @@ export function KanbanBoard({
   projects,
   onProjectAssignment,
   selectedTask,
+  onAddTask,
 }: KanbanBoardProps) {
   const [selectedAreas, setSelectedAreas] = useState<string[]>([]);
   const timeframes = ["NOW", "NEXT", "LATER", "SOMEDAY"] as const;

--- a/src/components/KanbanBoard.tsx
+++ b/src/components/KanbanBoard.tsx
@@ -47,6 +47,7 @@ interface KanbanBoardProps {
     area: string;
   }>;
   onProjectAssignment?: (task: Task, projectId: string) => void;
+  onAddTask?: (timeframe: "NOW" | "NEXT" | "LATER" | "SOMEDAY") => void;
 }
 
 const getPriorityCheckboxColor = (priority: string, cancelled: boolean = false) => {

--- a/src/components/KanbanBoard.tsx
+++ b/src/components/KanbanBoard.tsx
@@ -449,6 +449,7 @@ export function KanbanBoard({
             projects={projects}
             onProjectAssignment={onProjectAssignment}
             selectedTask={selectedTask}
+            onAddTask={onAddTask}
           />
         ))}
       </div>

--- a/src/components/KanbanBoard.tsx
+++ b/src/components/KanbanBoard.tsx
@@ -270,7 +270,8 @@ const KanbanColumn = ({
   areas,
   projects,
   onProjectAssignment,
-  selectedTask
+  selectedTask,
+  onAddTask
 }: {
   timeframe: "NOW" | "NEXT" | "LATER" | "SOMEDAY";
   tasks: Task[];
@@ -286,6 +287,7 @@ const KanbanColumn = ({
   }>;
   onProjectAssignment?: (task: Task, projectId: string) => void;
   selectedTask?: Task | null;
+  onAddTask?: (timeframe: "NOW" | "NEXT" | "LATER" | "SOMEDAY") => void;
 }) => {
   const [isDragOver, setIsDragOver] = useState(false);
 

--- a/src/components/TaskManagement.tsx
+++ b/src/components/TaskManagement.tsx
@@ -1550,7 +1550,7 @@ export function TaskManagement({ onTaskSidebarChange }: TaskManagementProps = {}
     // Only show tasks that have a project assigned (which gives them an area)
     const tasksWithProjects = tasks.filter(task => task.project);
     return <div className="h-full">
-      <KanbanBoard tasks={filterAndSortTasks(tasksWithProjects)} onTaskClick={handleTaskClick} onToggleTask={toggleTask} onUpdateTaskTimeframe={updateTaskTimeframe} onUpdateTaskDueDate={updateTaskDueDate} areas={mockAreas} selectedAreas={kanbanSelectedAreas} projects={mockProjects} onProjectAssignment={handleProjectAssignment} selectedTask={selectedTask} />
+      <KanbanBoard tasks={filterAndSortTasks(tasksWithProjects)} onTaskClick={handleTaskClick} onToggleTask={toggleTask} onUpdateTaskTimeframe={updateTaskTimeframe} onUpdateTaskDueDate={updateTaskDueDate} areas={mockAreas} selectedAreas={kanbanSelectedAreas} projects={mockProjects} onProjectAssignment={handleProjectAssignment} selectedTask={selectedTask} onAddTask={handleAddTaskByTimeframe} />
     </div>;
   };
   const getFilteredTasks = () => {

--- a/src/components/TaskManagement.tsx
+++ b/src/components/TaskManagement.tsx
@@ -581,6 +581,26 @@ export function TaskManagement({ onTaskSidebarChange }: TaskManagementProps = {}
     setTasks(prev => [...prev, newTask]);
   };
 
+  const handleAddTaskByTimeframe = (timeframe: "NOW" | "NEXT" | "LATER" | "SOMEDAY") => {
+    const newTask: Task = {
+      id: Date.now().toString(),
+      title: "New Task",
+      description: "",
+      priority: "medium",
+      completed: null,
+      cancelled: null,
+      dueDate: undefined,
+      timeInterval: undefined,
+      area: undefined,
+      project: undefined,
+      step: undefined,
+      created: new Date(),
+      timeframe: timeframe
+    };
+
+    setTasks(prev => [...prev, newTask]);
+  };
+
   const handleAssignTaskToStep = (taskId: string, stepId: string) => {
     setTasks(prevTasks => prevTasks.map(task =>
       task.id === taskId ? { ...task, step: stepId } : task

--- a/src/components/TaskManagement.tsx
+++ b/src/components/TaskManagement.tsx
@@ -337,6 +337,12 @@ const mockAreas: Area[] = [{
 // Import the full project data from ProjectManagement
 const mockProjects: Project[] = [
   {
+    id: "misc",
+    title: "Misc",
+    area: "work", // Default area, will be dynamically updated
+    steps: []
+  },
+  {
     id: "1",
     title: "Website Redesign",
     area: "work",

--- a/src/components/TaskManagement.tsx
+++ b/src/components/TaskManagement.tsx
@@ -1547,9 +1547,10 @@ export function TaskManagement({ onTaskSidebarChange }: TaskManagementProps = {}
     });
   };
   const renderAreasView = () => {
-    // Show all tasks in kanban view - both with and without projects
+    // Only show tasks that have a project assigned (which gives them an area) OR have a due date
+    const tasksWithProjectsOrDueDates = tasks.filter(task => task.project || task.dueDate);
     return <div className="h-full">
-      <KanbanBoard tasks={filterAndSortTasks(tasks)} onTaskClick={handleTaskClick} onToggleTask={toggleTask} onUpdateTaskTimeframe={updateTaskTimeframe} onUpdateTaskDueDate={updateTaskDueDate} areas={mockAreas} selectedAreas={kanbanSelectedAreas} projects={mockProjects} onProjectAssignment={handleProjectAssignment} selectedTask={selectedTask} onAddTask={handleAddTaskByTimeframe} />
+      <KanbanBoard tasks={filterAndSortTasks(tasksWithProjectsOrDueDates)} onTaskClick={handleTaskClick} onToggleTask={toggleTask} onUpdateTaskTimeframe={updateTaskTimeframe} onUpdateTaskDueDate={updateTaskDueDate} areas={mockAreas} selectedAreas={kanbanSelectedAreas} projects={mockProjects} onProjectAssignment={handleProjectAssignment} selectedTask={selectedTask} onAddTask={handleAddTaskByTimeframe} />
     </div>;
   };
   const getFilteredTasks = () => {

--- a/src/components/TaskManagement.tsx
+++ b/src/components/TaskManagement.tsx
@@ -582,6 +582,28 @@ export function TaskManagement({ onTaskSidebarChange }: TaskManagementProps = {}
   };
 
   const handleAddTaskByTimeframe = (timeframe: "NOW" | "NEXT" | "LATER" | "SOMEDAY") => {
+    // Find a suitable project to assign
+    let assignedProjectId: string | undefined;
+
+    if (kanbanSelectedAreas.length > 0) {
+      // If areas are filtered, find an active project from those areas
+      const projectsInSelectedAreas = mockProjects.filter(p =>
+        kanbanSelectedAreas.includes(p.area) && p.status === "active"
+      );
+      assignedProjectId = projectsInSelectedAreas.length > 0 ? projectsInSelectedAreas[0].id : undefined;
+    }
+
+    if (!assignedProjectId) {
+      // If no areas selected or no active projects in selected areas, find any active project
+      const activeProjects = mockProjects.filter(p => p.status === "active");
+      assignedProjectId = activeProjects.length > 0 ? activeProjects[0].id : undefined;
+    }
+
+    if (!assignedProjectId) {
+      // If no active projects, just use the first available project
+      assignedProjectId = mockProjects.length > 0 ? mockProjects[0].id : undefined;
+    }
+
     const newTask: Task = {
       id: Date.now().toString(),
       title: "New Task",
@@ -591,8 +613,8 @@ export function TaskManagement({ onTaskSidebarChange }: TaskManagementProps = {}
       cancelled: null,
       dueDate: undefined,
       timeInterval: undefined,
-      area: undefined,
-      project: undefined,
+      area: assignedProjectId ? getAreaFromProject(assignedProjectId) : undefined,
+      project: assignedProjectId,
       step: undefined,
       created: new Date(),
       timeframe: timeframe

--- a/src/components/TaskManagement.tsx
+++ b/src/components/TaskManagement.tsx
@@ -588,20 +588,18 @@ export function TaskManagement({ onTaskSidebarChange }: TaskManagementProps = {}
   };
 
   const handleAddTaskByTimeframe = (timeframe: "NOW" | "NEXT" | "LATER" | "SOMEDAY") => {
-    // Find a suitable project to assign
-    let assignedProjectId: string | undefined;
+    // Always use the misc project, but set its area based on current filter
+    let miscProjectArea = "work"; // Default area
 
     if (kanbanSelectedAreas.length > 0) {
-      // If areas are filtered, find a project from those areas
-      const projectsInSelectedAreas = mockProjects.filter(p =>
-        kanbanSelectedAreas.includes(p.area)
-      );
-      assignedProjectId = projectsInSelectedAreas.length > 0 ? projectsInSelectedAreas[0].id : undefined;
+      // If areas are filtered, use the first selected area
+      miscProjectArea = kanbanSelectedAreas[0];
     }
 
-    if (!assignedProjectId) {
-      // If no areas selected or no projects in selected areas, use the first available project
-      assignedProjectId = mockProjects.length > 0 ? mockProjects[0].id : undefined;
+    // Update the misc project's area dynamically (for getAreaFromProject function)
+    const miscProject = mockProjects.find(p => p.id === "misc");
+    if (miscProject) {
+      miscProject.area = miscProjectArea;
     }
 
     const newTask: Task = {
@@ -613,8 +611,8 @@ export function TaskManagement({ onTaskSidebarChange }: TaskManagementProps = {}
       cancelled: null,
       dueDate: undefined,
       timeInterval: undefined,
-      area: assignedProjectId ? getAreaFromProject(assignedProjectId) : undefined,
-      project: assignedProjectId,
+      area: miscProjectArea,
+      project: "misc",
       step: undefined,
       created: new Date(),
       timeframe: timeframe

--- a/src/components/TaskManagement.tsx
+++ b/src/components/TaskManagement.tsx
@@ -586,21 +586,15 @@ export function TaskManagement({ onTaskSidebarChange }: TaskManagementProps = {}
     let assignedProjectId: string | undefined;
 
     if (kanbanSelectedAreas.length > 0) {
-      // If areas are filtered, find an active project from those areas
+      // If areas are filtered, find a project from those areas
       const projectsInSelectedAreas = mockProjects.filter(p =>
-        kanbanSelectedAreas.includes(p.area) && p.status === "active"
+        kanbanSelectedAreas.includes(p.area)
       );
       assignedProjectId = projectsInSelectedAreas.length > 0 ? projectsInSelectedAreas[0].id : undefined;
     }
 
     if (!assignedProjectId) {
-      // If no areas selected or no active projects in selected areas, find any active project
-      const activeProjects = mockProjects.filter(p => p.status === "active");
-      assignedProjectId = activeProjects.length > 0 ? activeProjects[0].id : undefined;
-    }
-
-    if (!assignedProjectId) {
-      // If no active projects, just use the first available project
+      // If no areas selected or no projects in selected areas, use the first available project
       assignedProjectId = mockProjects.length > 0 ? mockProjects[0].id : undefined;
     }
 

--- a/src/components/TaskManagement.tsx
+++ b/src/components/TaskManagement.tsx
@@ -1547,10 +1547,9 @@ export function TaskManagement({ onTaskSidebarChange }: TaskManagementProps = {}
     });
   };
   const renderAreasView = () => {
-    // Only show tasks that have a project assigned (which gives them an area)
-    const tasksWithProjects = tasks.filter(task => task.project);
+    // Show all tasks in kanban view - both with and without projects
     return <div className="h-full">
-      <KanbanBoard tasks={filterAndSortTasks(tasksWithProjects)} onTaskClick={handleTaskClick} onToggleTask={toggleTask} onUpdateTaskTimeframe={updateTaskTimeframe} onUpdateTaskDueDate={updateTaskDueDate} areas={mockAreas} selectedAreas={kanbanSelectedAreas} projects={mockProjects} onProjectAssignment={handleProjectAssignment} selectedTask={selectedTask} onAddTask={handleAddTaskByTimeframe} />
+      <KanbanBoard tasks={filterAndSortTasks(tasks)} onTaskClick={handleTaskClick} onToggleTask={toggleTask} onUpdateTaskTimeframe={updateTaskTimeframe} onUpdateTaskDueDate={updateTaskDueDate} areas={mockAreas} selectedAreas={kanbanSelectedAreas} projects={mockProjects} onProjectAssignment={handleProjectAssignment} selectedTask={selectedTask} onAddTask={handleAddTaskByTimeframe} />
     </div>;
   };
   const getFilteredTasks = () => {


### PR DESCRIPTION
## Purpose

The user wanted to improve task creation workflow in the kanban view by:
- Adding "+ add task" buttons to each kanban column (NOW, NEXT, LATER, SOMEDAY) similar to the project detailed view
- Creating a "misc" project that serves as a default assignment for new tasks when area filters are active
- Ensuring the misc project adapts to the current area filter but remains hidden from Projects/Goals views
- Fixing issues where the add task button stopped working when certain area filters were applied

## Code changes

- **KanbanBoard.tsx**: Added `onAddTask` prop and "+ add task" buttons at the bottom of each kanban column
- **TaskManagement.tsx**: 
  - Created a "misc" project that dynamically updates its area based on current kanban filters
  - Implemented `handleAddTaskByTimeframe` function that creates tasks assigned to the misc project
  - Updated kanban task filtering to show tasks with projects OR due dates
  - Connected the kanban add task functionality to the new handler
- **GoalManagement.tsx**: Improved goal detail view layout with better project organization and drag-and-drop support

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 28`

🔗 [Edit in Builder.io](https://builder.io/app/projects/24457c5b64e74772a57c59e852e563a7/orbit-lab)

👀 [Preview Link](https://24457c5b64e74772a57c59e852e563a7-orbit-lab.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>24457c5b64e74772a57c59e852e563a7</projectId>-->
<!--<branchName>orbit-lab</branchName>-->